### PR TITLE
Make it possible to install in user context (without administrator privileges)

### DIFF
--- a/electron-app/electron-builder.yml
+++ b/electron-app/electron-builder.yml
@@ -44,7 +44,7 @@ linux:
 nsis:
   menuCategory: true
   oneClick: false
-  perMachine: true
+  perMachine: false
   installerHeaderIcon: resources/icon.ico
   installerIcon: resources/icon.ico
   uninstallerIcon: resources/icon.ico


### PR DESCRIPTION
#### What it does
Enables the user to select installation type on Windows for all users or only for current user:
* All users
* Current user 

No need to have administrator access to proceed with
installation for current user.
![](https://user-images.githubusercontent.com/48523374/106141528-86290a00-6170-11eb-905c-4d00e78c034f.png)

Contributed by STMicroelectronics

#### How to test

Run the installer on a windows machine, use an account without admin privileges and check that you are able to run Theia

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

