### PR TITLE
Use older debian version for build #41

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM node:12.19.0-buster
+FROM node:12.19.0-stretch
 RUN apt-get update && apt-get install -y libxkbfile-dev


### PR DESCRIPTION
Contributed on behalf of STMicroelectronics
Signed-off-by: Johannes Faltermeier <jfaltermeier@eclipsesource.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Uses stretch instead of buster for building theia-blueprint for Linux. 
See #41 

Contributed on behalf of STMicroelectronics
Signed-off-by: Johannes Faltermeier <jfaltermeier@eclipsesource.com>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Deploy a new version of thegecko/theia-dev with the modifed Dockerfile
Run a build on Jenkins
Verify that the AppImage is still working and that it is working on Ubuntu 18.04 now


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

