### PR TITLE
Make @theia/electron a development dependency

### DIFF
--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -39,7 +39,6 @@
     "@theia/debug": "1.10.0",
     "@theia/editor": "1.10.0",
     "@theia/editor-preview": "1.10.0",
-    "@theia/electron": "1.10.0",
     "@theia/file-search": "1.10.0",
     "@theia/filesystem": "1.10.0",
     "@theia/getting-started": "1.10.0",
@@ -90,7 +89,8 @@
     "mocha": "^8.2.1",
     "rimraf": "^2.7.1",
     "wdio-chromedriver-service": "^6.0.4",
-    "webdriverio": "^6.10.2"
+    "webdriverio": "^6.10.2",
+    "@theia/electron": "1.10.0"
   },
   "scripts": {
     "prepare": "yarn build && yarn download:plugins",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #48

ATM @theia/electron is a runtime dependency, that depends on the
"electron" package. As such both are preserved with the packaged
blueprint application.

Simple solution: make @theia/electron a dev-dependency, This way
it will be stripped when we package blueprint, somewhat reducing
our various package sizes. On Linux the expected size reduction
is 16MB.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Please see "steps to reproduce" in #48 and confirm that after the fix only a single version of Electron binaries are present in the unzipped package. 

Confirm that the app still generally starts and seems to works despite the absence of the package.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

