### PR TITLE
Reverting @theia/electron as dev-dependency

### DIFF
--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -39,6 +39,7 @@
     "@theia/debug": "1.11.0",
     "@theia/editor": "1.11.0",
     "@theia/editor-preview": "1.11.0",
+    "@theia/electron": "1.11.0",    
     "@theia/file-search": "1.11.0",
     "@theia/filesystem": "1.11.0",
     "@theia/getting-started": "1.11.0",
@@ -75,7 +76,6 @@
   },
   "devDependencies": {
     "@theia/cli": "1.11.0",
-    "@theia/electron": "1.11.0",
     "@wdio/cli": "^6.10.2",
     "@wdio/local-runner": "^6.10.2",
     "@wdio/mocha-framework": "^6.8.0",


### PR DESCRIPTION

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #52 by effectively reverting #49. I think I successfully tested that, but I can't make it work anymore, and the packages we generate are broken. It could be we actually need @theia/electron at runtime. Then we can instead try changing its electron dependency to a devDependency, which would remove the duplication of Electron binaries in our packages. 

#### How to test
Build and test the resulting app. E.g.:
```bash
$> yarn && yarn package
$> electron-app/dist/TheiaBlueprint-1.11.0.AppImage
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

