### PR TITLE
Switch to using eclipsetheia/theia-blueprint

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ kind: Pod
 spec:
   containers:
   - name: theia-dev
-    image: thegecko/theia-dev
+    image: eclipsetheia/theia-blueprint
     command:
     - cat
     tty: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,10 +29,10 @@ spec:
     tty: true
     resources:
       limits:
-        memory: "4Gi"
+        memory: "8Gi"
         cpu: "2"
       requests:
-        memory: "4Gi"
+        memory: "8Gi"
         cpu: "2"
     volumeMounts:
     - name: yarn-cache

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,8 @@ releaseBranch = "master"
 pipeline {
     agent none
     options {
-        timeout(time: 5, unit: 'HOURS') 
+        timeout(time: 5, unit: 'HOURS')
+        disableConcurrentBuilds()
     }
     stages {
         stage('Build') {


### PR DESCRIPTION
Update to use the new docker hub repo:

https://hub.docker.com/repository/docker/eclipsetheia/theia-blueprint