### PR TITLE
Cleanup of a few more stray uses of the word 'product'

### DIFF
--- a/theia-blueprint-product/src/browser/theia-blueprint-about-dialog.tsx
+++ b/theia-blueprint-product/src/browser/theia-blueprint-about-dialog.tsx
@@ -79,7 +79,7 @@ export class TheiaBlueprintAboutDialog extends AboutDialog {
 
     protected renderTitle(): React.ReactNode {
         return <div className='gs-header'>
-            <h1>Eclipse Theia <span className='gs-blue-header'>Blueprint</span> Product</h1>
+            <h1>Eclipse Theia <span className='gs-blue-header'>Blueprint</span></h1>
             {this.renderVersion()}
         </div>;
     }

--- a/theia-blueprint-product/src/browser/theia-blueprint-getting-started-widget.tsx
+++ b/theia-blueprint-product/src/browser/theia-blueprint-getting-started-widget.tsx
@@ -64,7 +64,7 @@ export class TheiaBlueprintGettingStartedWidget extends GettingStartedWidget {
 
     protected renderHeader(): React.ReactNode {
         return <div className='gs-header'>
-            <h1>Eclipse Theia <span className='gs-blue-header'>Blueprint</span> Product</h1>
+            <h1>Eclipse Theia <span className='gs-blue-header'>Blueprint</span></h1>
             {this.renderVersion()}
         </div>;
     }


### PR DESCRIPTION
Cleanup of a few more stray uses of the word 'product' in the application name

Signed-off-by: Brian King <brian.king@eclipse-foundation.org>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
After starting up the latest alpha built, I noticed 'product' still in the title of the welcome page, so I changed it and a couple more instances I found.

#### How to test
In build with fix, open Welcome Page, About Dialog. Also check README in repo.

#### Review checklist

- [ ✅] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

