### PR TITLE
config: add custom home configuration folder

### DIFF
--- a/.vscode/theia.code-snippets
+++ b/.vscode/theia.code-snippets
@@ -1,0 +1,11 @@
+{
+    "Copyright-JS/JSX/TS/TSX/CSS": {
+        "prefix": [
+            "header",
+            "copyright"
+        ],
+        "body": "/********************************************************************************\n * Copyright (C) $CURRENT_YEAR ${YourCompany} and others.\n *\n * This program and the accompanying materials are made available under the\n * terms of the Eclipse Public License v. 2.0 which is available at\n * http://www.eclipse.org/legal/epl-2.0.\n *\n * This Source Code may also be made available under the following Secondary\n * Licenses when the conditions for such availability set forth in the Eclipse\n * Public License v. 2.0 are satisfied: GNU General Public License, version 2\n * with the GNU Classpath Exception which is available at\n * https://www.gnu.org/software/classpath/license.html.\n *\n * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0\n ********************************************************************************/\n\n$0",
+        "description": "Adds the copyright...",
+        "scope": "javascript,javascriptreact,typescript,typescriptreact,css"
+    }
+}

--- a/theia-blueprint-product/package.json
+++ b/theia-blueprint-product/package.json
@@ -13,7 +13,8 @@
   },
   "theiaExtensions": [
     {
-      "frontendElectron": "lib/browser/theia-blueprint-frontend-module"
+      "frontendElectron": "lib/browser/theia-blueprint-frontend-module",
+      "backend": "lib/node/theia-blueprint-backend-module"
     }
   ],
   "keywords": [

--- a/theia-blueprint-product/src/node/theia-blueprint-backend-module.ts
+++ b/theia-blueprint-product/src/node/theia-blueprint-backend-module.ts
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { TheiaBlueprintEnvVariableServer } from './theia-blueprint-variables-server';
+
+export default new ContainerModule((bind, unbind, isBound, rebind) => {
+    rebind(EnvVariablesServer).to(TheiaBlueprintEnvVariableServer).inSingletonScope();
+});

--- a/theia-blueprint-product/src/node/theia-blueprint-variables-server.ts
+++ b/theia-blueprint-product/src/node/theia-blueprint-variables-server.ts
@@ -1,0 +1,33 @@
+/********************************************************************************
+ * Copyright (C) 2021 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as os from 'os';
+import * as path from 'path';
+import { injectable } from 'inversify';
+import { FileUri } from '@theia/core/lib/node/file-uri'
+import { EnvVariablesServerImpl } from '@theia/core/lib/node/env-variables';
+
+@injectable()
+export class TheiaBlueprintEnvVariableServer extends EnvVariablesServerImpl {
+
+    protected readonly _configDirUri: string = FileUri.create(path.join(os.homedir(), '.theia-blueprint')).toString(true);
+
+    async getConfigDirUri(): Promise<string> {
+        return this._configDirUri;
+    }
+
+}
+


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Related: https://github.com/eclipse-theia/theia-blueprint/issues/25#issuecomment-811871499.

The pull-request adds the following functionality:
- adds a custom configuration folder name (`.theia` > `.theia-blueprint`) to be used instead of the default.
- adds header snippets (from the upstream repository) to make it easier to add headers in the future.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- build and start the application.
- confirm that the `~/.theia-blueprint` folder exists on the filesystem.
- set user scope preferences, install extensions, and ensure they are saved under `~/.theia-blueprint`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>