### PR TITLE
Theia electron installer on windows has a hard coded default path #35

### DIFF
--- a/applications/electron/package.json
+++ b/applications/electron/package.json
@@ -6,7 +6,7 @@
   "version": "1.13.0",
   "main": "scripts/theia-electron-main.js",
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
-  "author": "Rob Moran <github@thegecko.org>",
+  "author": "Eclipse Theia <theia-dev@eclipse.org>",
   "homepage": "https://github.com/eclipse-theia/theia-blueprint#readme",
   "bugs": {
     "url": "https://github.com/eclipse-theia/theia/issues"


### PR DESCRIPTION
#### What it does
The affected section of the path is taken from the electron-app's author name. 
-> Change to "Eclipse Theia"

closes #35 

#### How to test
Build the windows installer and check the installation path for all users. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

