### PR TITLE
Show vscode extension API version in About dialog #86

### DIFF
--- a/theia-extensions/theia-blueprint-product/package.json
+++ b/theia-extensions/theia-blueprint-product/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@theia/core": "1.14.0",
     "@theia/getting-started": "^1.14.0",
+    "@theia/vsx-registry": "^1.14.0",
     "@theia/workspace": "^1.14.0",
     "inversify": "^5.1.1"
   },

--- a/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-about-dialog.tsx
+++ b/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-about-dialog.tsx
@@ -16,16 +16,27 @@
 import * as React from 'react';
 
 import { AboutDialog, AboutDialogProps, ABOUT_CONTENT_CLASS } from '@theia/core/lib/browser/about-dialog';
-import { injectable, inject } from 'inversify';
+import { injectable, inject, postConstruct } from 'inversify';
 import { renderDocumentation, renderDownloads, renderSourceCode, renderTickets, renderWhatIs, renderWhatIsNot } from './branding-util';
+import { VSXEnvironment } from '@theia/vsx-registry/lib/common/vsx-environment';
 
 @injectable()
 export class TheiaBlueprintAboutDialog extends AboutDialog {
 
+    @inject(VSXEnvironment)
+    protected readonly environment: VSXEnvironment;
+
+    protected vsCodeApi: string;
     constructor(
         @inject(AboutDialogProps) protected readonly props: AboutDialogProps
     ) {
         super(props);
+    }
+
+    @postConstruct()
+    protected async init(): Promise<void> {
+        this.vsCodeApi = await this.environment.getVscodeApiVersion();
+        super.init();
     }
 
     protected render(): React.ReactNode {
@@ -85,8 +96,14 @@ export class TheiaBlueprintAboutDialog extends AboutDialog {
     }
 
     protected renderVersion(): React.ReactNode {
-        return <p className='gs-sub-header' >
-            {this.applicationInfo ? 'Version ' + this.applicationInfo.version + ' (Alpha)' : '(Alpha)'}
-        </p>;
+        return <div>
+            <p className='gs-sub-header' >
+                {this.applicationInfo ? 'Version ' + this.applicationInfo.version + ' (Alpha)' : '(Alpha)'}
+            </p>
+
+            <p className='gs-sub-header' >
+                {'VS Code API Version: ' + this.vsCodeApi}
+            </p>
+        </div>;
     }
 }

--- a/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-about-dialog.tsx
+++ b/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-about-dialog.tsx
@@ -16,27 +16,20 @@
 import * as React from 'react';
 
 import { AboutDialog, AboutDialogProps, ABOUT_CONTENT_CLASS } from '@theia/core/lib/browser/about-dialog';
-import { injectable, inject, postConstruct } from 'inversify';
+import { injectable, inject } from 'inversify';
 import { renderDocumentation, renderDownloads, renderSourceCode, renderTickets, renderWhatIs, renderWhatIsNot } from './branding-util';
-import { VSXEnvironment } from '@theia/vsx-registry/lib/common/vsx-environment';
+import { VSXApiVersionProvider } from '@theia/vsx-registry/lib/common/vsx-api-version-provider';
 
 @injectable()
 export class TheiaBlueprintAboutDialog extends AboutDialog {
 
-    @inject(VSXEnvironment)
-    protected readonly environment: VSXEnvironment;
+    @inject(VSXApiVersionProvider)
+    protected readonly apiVersionProvider: VSXApiVersionProvider;
 
-    protected vsCodeApi: string;
     constructor(
         @inject(AboutDialogProps) protected readonly props: AboutDialogProps
     ) {
         super(props);
-    }
-
-    @postConstruct()
-    protected async init(): Promise<void> {
-        this.vsCodeApi = await this.environment.getVscodeApiVersion();
-        super.init();
     }
 
     protected render(): React.ReactNode {
@@ -102,7 +95,7 @@ export class TheiaBlueprintAboutDialog extends AboutDialog {
             </p>
 
             <p className='gs-sub-header' >
-                {'VS Code API Version: ' + this.vsCodeApi}
+                {'VS Code API Version: ' + this.apiVersionProvider.getApiVersion()}
             </p>
         </div>;
     }

--- a/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-widget.tsx
+++ b/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-widget.tsx
@@ -18,10 +18,14 @@ import * as React from 'react';
 import { renderDocumentation, renderDownloads, renderSourceCode, renderTickets, renderWhatIs, renderWhatIsNot } from './branding-util';
 
 import { GettingStartedWidget } from '@theia/getting-started/lib/browser/getting-started-widget';
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
+import { VSXApiVersionProvider } from '@theia/vsx-registry/lib/common/vsx-api-version-provider';
 
 @injectable()
 export class TheiaBlueprintGettingStartedWidget extends GettingStartedWidget {
+
+    @inject(VSXApiVersionProvider)
+    protected readonly apiVersionProvider: VSXApiVersionProvider;
 
     protected render(): React.ReactNode {
         return <div className='gs-container'>
@@ -98,8 +102,14 @@ export class TheiaBlueprintGettingStartedWidget extends GettingStartedWidget {
     }
 
     protected renderVersion(): React.ReactNode {
-        return <p className='gs-sub-header' >
-            {this.applicationInfo ? 'Version ' + this.applicationInfo.version + ' (Alpha)' : '(Alpha)'}
-        </p>;
+        return <div>
+            <p className='gs-sub-header' >
+                {this.applicationInfo ? 'Version ' + this.applicationInfo.version + ' (Alpha)' : '(Alpha)'}
+            </p>
+
+            <p className='gs-sub-header' >
+                {'VS Code API Version: ' + this.apiVersionProvider.getApiVersion()}
+            </p>
+        </div>;
     }
 }


### PR DESCRIPTION
#### What it does
Shows vscode extension API version in About dialog

![ksnip_20210527-102518](https://user-images.githubusercontent.com/5889696/120187714-76e8c480-c215-11eb-8850-7a9a19991138.png)

closes #86

#### How to test
Build and check about dialog

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

