### PR TITLE
Fix Jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,10 +136,16 @@ spec:
 def buildInstaller() {
     checkout scm
     // clear electron-gyp volume content to avoid occasional CI issue
-    sh "rm -rf /.electron-gyp/*"
-    sh "printenv"
-    sh "yarn cache clean"
-    sh "yarn --frozen-lockfile --force"
+    sh "ls -al /.electron-gyp/ || /bin/true"
+    sh "ls -al /.cache/ || /bin/true"
+    sh "df -h || /bin/true"
+    // sh "rm -rf /.electron-gyp/*"
+    // sh "ls -al /.electron-gyp/"
+    sh "printenv && yarn cache dir"
+    // sh "yarn cache clean"
+    sh "yarn --frozen-lockfile --force || yarn"
+    sh "ls -al /.electron-gyp/ || /bin/true"
+    sh "ls -al /.cache/ || /bin/true"
     sh "rm -rf ./${distFolder}"
     sshagent(['projects-storage.eclipse.org-bot-ssh']) {
         sh "yarn electron deploy"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,8 +135,8 @@ spec:
 
 def buildInstaller() {
     checkout scm
-    // clear volumes to avoid occasional CI issue
-    sh "rm -rf /.cache/* /.electron-gyp/*"
+    // clear electron-gyp volume content to avoid occasional CI issue
+    sh "rm -rf /.electron-gyp/*"
     sh "printenv"
     sh "yarn cache clean"
     sh "yarn --frozen-lockfile --force"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Jenkins has been failing recently, following an attempt
at improving it, [by clearing the caches](https://github.com/eclipse-theia/theia-blueprint/blob/master/Jenkinsfile#L139). I noticed some
signs that the /.cache folder is used for more than yarn,
and so should probably not be wiped altogether.

This commit rolls-back the deletion of `/.cache/*` and instead
relies on existing "yarn cache clean" to do that job.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
The first sigh is that hopefully CI passes. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

