### PR TITLE
Revert "Delete content of Jenkins job cache folders"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,8 +135,6 @@ spec:
 
 def buildInstaller() {
     checkout scm
-    // clear volumes to avoid occasional CI issue
-    sh "rm -rf /.cache/* /.electron-gyp/*"
     sh "printenv"
     sh "yarn cache clean"
     sh "yarn --frozen-lockfile --force"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This reverts commit ad5a73c519d79d740e808296c1520962749ad167.

That committ was an attempt at improving the Jenkins CI reliability, but it has caused issues:
- the command is not OS-agnostic and does not work on at least Windows
- the /.cache folder, despite it's label, contains more than yarn, so removing it altogether is not a good idea. In any case `yarn cache clean` works perfectly, AFAICT. The attempted fix was more to address the 'electron-gyp` folder.

I might come-back with a follow-up, if I can successfully improve CI

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

