### PR TITLE
Getting started shown twice in help menu #110

### DIFF
--- a/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-contribution.ts
+++ b/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-contribution.ts
@@ -14,24 +14,27 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { AbstractViewContribution, FrontendApplication, FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from 'inversify';
 
-import { FrontendApplication } from '@theia/core/lib/browser';
 import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
-import { GettingStartedContribution } from '@theia/getting-started/lib/browser/getting-started-contribution';
-import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { GettingStartedWidget } from '@theia/getting-started/lib/browser/getting-started-widget';
+import { TheiaBlueprintGettingStartedWidget } from './theia-blueprint-getting-started-widget';
 
 @injectable()
-export class TheiaBlueprintGettingStartedContribution extends GettingStartedContribution {
+export class TheiaBlueprintGettingStartedContribution extends AbstractViewContribution<TheiaBlueprintGettingStartedWidget> implements FrontendApplicationContribution {
 
     @inject(FrontendApplicationStateService)
     protected readonly stateService: FrontendApplicationStateService;
 
-    @inject(WorkspaceService)
-    protected readonly workspaceService: WorkspaceService;
-
     constructor() {
-        super();
+        super({
+            widgetId: GettingStartedWidget.ID,
+            widgetName: GettingStartedWidget.LABEL,
+            defaultWidgetOptions: {
+                area: 'main',
+            }
+        });
     }
 
     async onStart(app: FrontendApplication): Promise<void> {


### PR DESCRIPTION
#### What it does

* avoid contributing the menu contributions twice

closes #110 

#### How to test
Build and check that the help menu has only one "Getting Started" entry and that the welcome page is still shown on every launch even when a workspace is already opened.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

