### PR TITLE
Update `about` and `getting-started` api-version handling

### DIFF
--- a/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-about-dialog.tsx
+++ b/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-about-dialog.tsx
@@ -16,20 +16,28 @@
 import * as React from 'react';
 
 import { AboutDialog, AboutDialogProps, ABOUT_CONTENT_CLASS } from '@theia/core/lib/browser/about-dialog';
-import { injectable, inject } from 'inversify';
+import { injectable, inject, postConstruct } from 'inversify';
 import { renderDocumentation, renderDownloads, renderSourceCode, renderTickets, renderWhatIs, renderWhatIsNot } from './branding-util';
-import { VSXApiVersionProvider } from '@theia/vsx-registry/lib/common/vsx-api-version-provider';
+import { VSXEnvironment } from '@theia/vsx-registry/lib/common/vsx-environment';
 
 @injectable()
 export class TheiaBlueprintAboutDialog extends AboutDialog {
 
-    @inject(VSXApiVersionProvider)
-    protected readonly apiVersionProvider: VSXApiVersionProvider;
+    @inject(VSXEnvironment)
+    protected readonly environment: VSXEnvironment;
+
+    protected vscodeApiVersion: string;
 
     constructor(
         @inject(AboutDialogProps) protected readonly props: AboutDialogProps
     ) {
         super(props);
+    }
+
+    @postConstruct()
+    protected async init(): Promise<void> {
+        this.vscodeApiVersion = await this.environment.getVscodeApiVersion();
+        super.init();
     }
 
     protected render(): React.ReactNode {
@@ -95,7 +103,7 @@ export class TheiaBlueprintAboutDialog extends AboutDialog {
             </p>
 
             <p className='gs-sub-header' >
-                {'VS Code API Version: ' + this.apiVersionProvider.getApiVersion()}
+                {'VS Code API Version: ' + this.vscodeApiVersion}
             </p>
         </div>;
     }

--- a/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-widget.tsx
+++ b/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-widget.tsx
@@ -15,17 +15,26 @@
  ********************************************************************************/
 import * as React from 'react';
 
-import { inject, injectable } from 'inversify';
+import { inject, injectable, postConstruct } from 'inversify';
 import { renderDocumentation, renderDownloads, renderSourceCode, renderTickets, renderWhatIs, renderWhatIsNot } from './branding-util';
 
 import { GettingStartedWidget } from '@theia/getting-started/lib/browser/getting-started-widget';
-import { VSXApiVersionProvider } from '@theia/vsx-registry/lib/common/vsx-api-version-provider';
+import { VSXEnvironment } from '@theia/vsx-registry/lib/common/vsx-environment';
 
 @injectable()
 export class TheiaBlueprintGettingStartedWidget extends GettingStartedWidget {
 
-    @inject(VSXApiVersionProvider)
-    protected readonly apiVersionProvider: VSXApiVersionProvider;
+    @inject(VSXEnvironment)
+    protected readonly environment: VSXEnvironment;
+
+    protected vscodeApiVersion: string;
+
+    @postConstruct()
+    protected async init(): Promise<void> {
+        super.init();
+        this.vscodeApiVersion = await this.environment.getVscodeApiVersion();
+        this.update();
+    }
 
     protected render(): React.ReactNode {
         return <div className='gs-container'>
@@ -108,7 +117,7 @@ export class TheiaBlueprintGettingStartedWidget extends GettingStartedWidget {
             </p>
 
             <p className='gs-sub-header' >
-                {'VS Code API Version: ' + this.apiVersionProvider.getApiVersion()}
+                {'VS Code API Version: ' + this.vscodeApiVersion}
             </p>
         </div>;
     }


### PR DESCRIPTION



<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit updates the vscode api version for the `about` and `getting-started` views to use a non-deprecated way to determine the currently supported API version following recent changes to the framework.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. perform `yarn`
2. start the electron app - `(cd applications/electron && yarn start)`
3. confirm that the `about` dialog displays correctly, and has the proper api version
4. confirm that the `getting-started` page displays correctly and has the proper api version

![image](https://user-images.githubusercontent.com/40359487/122249628-fffb2f00-ce96-11eb-8fb1-173f25a934db.png)

![image](https://user-images.githubusercontent.com/40359487/122249670-0a1d2d80-ce97-11eb-86a2-f7c7319a085a.png)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

