### PR TITLE
[Jenkins] "OutOfMemoryError: Java heap space" during stash

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ spec:
                                 buildInstaller()
                             }
                         }
-                        stash name: 'linux'
+                        stash includes: "${distFolder}/**/*", name: 'linux'
                     }
                     post {
                         failure {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
* Only stash directory containing linux installer for linux

closes #120 

#### How to test
Check CI

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

