### PR TITLE
[WIP] use generic docker image for CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ kind: Pod
 spec:
   containers:
   - name: theia-dev
-    image: eclipsetheia/theia-blueprint
+    image: node:12.19.0-stretch
     command:
     - cat
     tty: true
@@ -58,6 +58,7 @@ spec:
                     }
                     steps {
                         container('theia-dev') {
+                            sh 'apt-get update && apt-get install -y libxkbfile-dev libsecret-1-dev'
                             script {
                                 buildInstaller()
                             }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Since it may be difficult to get write access to the docker hub
organization, let's experiment using a generic image, on which we
programatically install the couple of needed packages, on top.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Make sure Jenkins CI passes

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

