### PR TITLE
[ci] add workflow to rebuild and publish builder image

### DIFF
--- a/.github/workflows/publish-builder-img.yml
+++ b/.github/workflows/publish-builder-img.yml
@@ -1,0 +1,28 @@
+name: Publish builder image
+
+on:
+  schedule:
+    - cron: "0 0 1 * *" # runs 1st day of every month
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and push builder image to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: eclipsetheia/theia-blueprint:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,7 @@
+# See the associated GitHub workflow, that builds and publishes
+# this docker image to Docker Hub:
+# .github/workflows/publish-builder-img.yml
+# It can be triggered manually from the GitHub project page. 
+
 FROM node:12.19.0-stretch
 RUN apt-get update && apt-get install -y libxkbfile-dev libsecret-1-dev


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
This PR adds a GH workflow that builds  our Blueprint builder image and publishes it to Docker Hub. The workflow should be able to be triggered from the `Actions` tab on our GH project and as a fallback it's scheduled to run the 1st of every month. 

#### How to test
As a troubleshooting step, I first had the image build on any push, and so the current `Dockerfile` has [already been published](https://github.com/eclipse-theia/theia-blueprint/runs/3145434270?check_suite_focus=true). 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

