### PR TITLE
Fix incorrect `@theia` dependency version ranges

### DIFF
--- a/theia-extensions/theia-blueprint-product/package.json
+++ b/theia-extensions/theia-blueprint-product/package.json
@@ -5,9 +5,9 @@
   "description": "Eclipse Theia Blueprint Product Branding",
   "dependencies": {
     "@theia/core": "1.14.0",
-    "@theia/getting-started": "^1.14.0",
-    "@theia/vsx-registry": "^1.14.0",
-    "@theia/workspace": "^1.14.0",
+    "@theia/getting-started": "1.14.0",
+    "@theia/vsx-registry": "1.14.0",
+    "@theia/workspace": "1.14.0",
     "inversify": "^5.1.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1357,7 +1357,7 @@
     uuid "^8.0.0"
     vscode-languageserver-textdocument "^1.0.1"
 
-"@theia/getting-started@1.14.0", "@theia/getting-started@^1.14.0":
+"@theia/getting-started@1.14.0":
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/@theia/getting-started/-/getting-started-1.14.0.tgz#76a1cc1d989cc11f4b366349fc306066d025bd33"
   integrity sha512-tqt7WsAGxi5OOQcU58QxMOTy3We62NrvFUrdwm5oLH6qM8K+awEELrYnRDDFbU2McPVBFh8bXjRqunv8yULMNA==


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit addresses issues where building the project caused `yarn.lock` updates, and would pull different versions of the framework.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. confirm that `yarn` does not cause git changes
2. confirm that `yarn start:electron` works

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
