### PR TITLE
Fix webpack config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 **/dist
 **/lib
 **/src-gen
-**/webpack.config.js
 **/gen-webpack.config.js
 **/plugins
 **/tsconfig.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -37,11 +37,14 @@ Eclipse Theia Blueprint is ***not*** **a production-ready product**. Therefore, 
 
 ## Development
 
+### Requirements
+Please check Theia's [prerequisites](https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites), and keep node versions aligned between Theia Blueprint and that of the referenced Theia version.
+
 ### Documentation
 
 Documentation on how to package Theia as a Desktop Product may be found [here](https://theia-ide.org/docs/blueprint_documentation/)
 
-### Repository structure
+### Repository Structure
 
 - Root level configures mono-repo build with lerna
 - `applications` groups the different app targets
@@ -56,7 +59,7 @@ Documentation on how to package Theia as a Desktop Product may be found [here](h
 yarn
 ```
 
-### Package the application
+### Package the Application
 
 ```sh
 yarn electron package
@@ -64,7 +67,7 @@ yarn electron package
 
 The packaged application is located in `applications/electron/dist`.
 
-### Create a preview application (without packaging it)
+### Create a Preview Application (without packaging it)
 
 ```sh
 yarn electron package:preview
@@ -86,7 +89,7 @@ yarn electron test
 
 - [_"Don't expect that you can build app for all platforms on one platform."_](https://www.electron.build/multi-platform-build)
 
-### Reporting feature requests and bugs
+### Reporting Feature Requests and Bugs
 
 The features in Eclipse Theia Blueprint are based on Theia and the included extensions/plugins. For bugs in Theia please consider opening an issue in the [Theia project on Github](https://github.com/eclipse-theia/theia/issues/new/choose).
 Eclipse Theia Blueprint only packages existing functionality into a product and installers for the product. If you believe there is a mistake in packaging, something needs to be added to the packaging or the installers do not work properly, please [open an issue on Github](https://github.com/eclipse-theia/theia-blueprint/issues/new/choose) to let us know.

--- a/applications/electron/webpack.config.js
+++ b/applications/electron/webpack.config.js
@@ -1,0 +1,17 @@
+/**
+ * This file can be edited to customize webpack configuration.
+ * To reset delete this file and rerun theia build again.
+ */
+// @ts-check
+const config = require('./gen-webpack.config.js');
+
+/**
+ * Expose bundled modules on window.theia.moduleName namespace, e.g.
+ * window['theia']['@theia/core/lib/common/uri'].
+ * Such syntax can be used by external code, for instance, for testing.
+config.module.rules.push({
+    test: /\.js$/,
+    loader: require.resolve('@theia/application-manager/lib/expose-loader')
+}); */
+
+module.exports = config;


### PR DESCRIPTION
#### What it does
Checks the user configurable `webpack.congig.js` into the git.

close #134

#### How to test
- see [e2e-est](https://github.com/eclipse-theia/theia-blueprint/blob/master/README.md#running-e2e-tests) 
- make sure that file is not ignored

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

