### PR TITLE
[ci] Proceed with signing only during Jenkins CI on Mac

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,9 @@ pipeline {
         timeout(time: 5, unit: 'HOURS')
         disableConcurrentBuilds()
     }
+    environment {
+        BLUEPRINT_JENKINS_CI = 'true'
+    }
     stages {
         stage('Build') {
             parallel {

--- a/applications/electron/scripts/after-pack.js
+++ b/applications/electron/scripts/after-pack.js
@@ -37,6 +37,8 @@ const signFile = file => {
 };
 
 exports.default = async function(context) {
+    const running_ci = process.env.BLUEPRINT_JENKINS_CI == 'true';
+    const running_on_mac = context.packager.platform.name == 'mac';
     const appPath = path.resolve(context.appOutDir, `${context.packager.appInfo.productFilename}.app`);
 
     // Remove anything we don't want in the final package
@@ -46,9 +48,12 @@ exports.default = async function(context) {
         await asynfRimraf(resolvedPath);
     }
 
-    // Only continue for macOS
-    if (context.packager.platform.name !== 'mac') {
-        return;
+    // Only continue for macOS during CI
+    if (running_ci && running_on_mac) {
+        console.log("Detected Blueprint Jenkins CI on Mac - proceed with signing");
+    } else {
+        console.log("Skip Mac CI signing");
+        return
     }
 
     // Use app-builder-lib to find all binaries to sign, at this level it will include the final .app


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
ATM we have a post-packaging step that proceeds to sign
binaries from the Mac package. This can only work during
Jenkins CI, since it uses Eclipse Foundation infrastructure,
which is only configured for that context.

Since no distinction is made whether the context is CI or
something else, the same happens whenever someone on a Mac
attempts to follow the README instructions to try-out
building and locally packaging Blueprint. This can lead to
confusion and a generally bad experience.

This PR sets-up an environment variable in the Jenkins
config, and makes signing conditional to the presence of
this variable.

Fixes #138

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
On a Mac, confirm that you can package without being prompted for the password of `projects-storage.eclipse.org`:
```
genie.theia@projects-storage.eclipse.org's password: 
```
Also confirm that Jenkins still attempts-to sign binaries for the Mac platform. There will be such entries in the Jenkins log: 
```
Signing /Users/genie.theia/jenkins_agent/workspace/theia-example_PR-137/applications/electron/dist/mac/TheiaBlueprint.app/Contents/Frameworks/TheiaBlueprint Helper (Plugin).app...
+ INPUT='TheiaBlueprint Helper (Plugin).app'
+ ENTITLEMENTS=/Users/genie.theia/jenkins_agent/workspace/theia-example_PR-137/applications/electron/entitlements.plist
+ NEEDS_UNZIP=false
+ '[' -d 'TheiaBlueprint Helper (Plugin).app' ']'
+ NEEDS_UNZIP=true
+ zip -r -q -y unsigned.zip 'TheiaBlueprint Helper (Plugin).app'
+ rm -rf 'TheiaBlueprint Helper (Plugin).app'
+ INPUT=unsigned.zip
+ scp -p unsigned.zip genie.theia@projects-storage.eclipse.org:./
+ rm -f unsigned.zip
+ scp -p /Users/genie.theia/jenkins_agent/workspace/theia-example_PR-137/applications/electron/entitlements.plist genie.theia@projects-storage.eclipse.org:./entitlements.plist
+ REMOTE_NAME=unsigned.zip
+ ssh -q genie.theia@projects-storage.eclipse.org curl -o '"signed-unsigned.zip"' -F 'file=@"unsigned.zip"' -F entitlements=@entitlements.plist http://build.eclipse.org:31338/macsign.php
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  222k  100  111k  100  111k   428k   428k --:--:-- --:--:-- --:--:--  860k
+ scp -T -p 'genie.theia@projects-storage.eclipse.org:"./signed-unsigned.zip"' unsigned.zip
+ ssh -q genie.theia@projects-storage.eclipse.org rm -f '"unsigned.zip"' '"signed-unsigned.zip"' entitlements.plist
+ '[' true = true ']'
+ unzip -qq unsigned.zip
+ '[' 0 -ne 0 ']'
+ rm -f unsigned.zip
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

