### PR TITLE
Removed Eclipse key bindings

### DIFF
--- a/applications/electron/package.json
+++ b/applications/electron/package.json
@@ -117,7 +117,6 @@
     "vscjava.vscode-java-test": "https://open-vsx.org/api/vscjava/vscode-java-test/0.26.1/file/vscjava.vscode-java-test-0.26.1.vsix",
     "vscjava.vscode-maven": "https://open-vsx.org/api/vscjava/vscode-maven/0.21.2/file/vscjava.vscode-maven-0.21.2.vsix",
     "vscjava.vscode-java-dependency": "https://open-vsx.org/api/vscjava/vscode-java-dependency/0.16.0/file/vscjava.vscode-java-dependency-0.16.0.vsix",
-    "alphabotsec.vscode-eclipse-keybindings": "https://open-vsx.org/api/alphabotsec/vscode-eclipse-keybindings/0.12.0/file/alphabotsec.vscode-eclipse-keybindings-0.12.0.vsix",
     "ms-vscode.js-debug": "https://open-vsx.org/api/ms-vscode/js-debug/1.52.2/file/ms-vscode.js-debug-1.52.2.vsix",
     "vscode.css": "https://open-vsx.org/api/vscode/css/1.52.1/file/vscode.css-1.52.1.vsix",
     "vscode.css-language-features": "https://open-vsx.org/api/vscode/css-language-features/1.52.1/file/vscode.css-language-features-1.52.1.vsix",


### PR DESCRIPTION
fixed #123

Signed-off-by: Jonas Helming <jhelming@eclipsesource.com>

#### What it does
Removes the Eclipse key bindings

#### How to test
Press CTRL+D, it should not delete a line

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

