### PR TITLE
Remove "Skip Mac CI signing" printout if not on Mac

### DIFF
--- a/applications/electron/scripts/after-pack.js
+++ b/applications/electron/scripts/after-pack.js
@@ -52,7 +52,9 @@ exports.default = async function(context) {
     if (running_ci && running_on_mac) {
         console.log("Detected Blueprint Jenkins CI on Mac - proceed with signing");
     } else {
-        console.log("Skip Mac CI signing");
+        if (running_on_mac) {
+            console.log("Skip Mac CI signing");
+        }
         return
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This is a follow-up on the recent commit that made signing
on Mac happen only when running Jenkins CI. The printout
above was added for all operating systems, but it really
only makes sense to have it when one is running on a Mac.

This commit removes the printout on other platforms.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- [ ] on a Mac, build locally and produce a package. Confirm that the printout about skipping signing is present
- [ ] on Linux or Windows, build locally and produce a package. Confirm that the printout about skipping signing is __not__ present
- [ ] In both cases, signing should not be attempted

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

