### PR TITLE
[CI] Streamline project's CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build, package and test
 
 on:
   push:
@@ -42,13 +42,32 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Build
+      - name: Build and package
         shell: bash
         run: |
           yarn --skip-integrity-check --network-timeout 100000
+          yarn electron package
         env:
           NODE_OPTIONS: --max_old_space_size=4096
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://github.com/microsoft/vscode-ripgrep/issues/9
+
+      - name: Test (Linux)
+        if: matrix.tests != 'skip' && runner.os == 'Linux'
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: yarn electron test
+
+      - name: Test (Windows)
+        if: matrix.tests != 'skip' && runner.os == 'Windows'
+        shell: bash
+        run: |
+          yarn electron test
+
+      - name: Test (macOS)
+        if: matrix.tests != 'skip' && runner.os == 'macOS'
+        shell: bash
+        run: |
+          yarn electron test
 
       - name: Lint
         if: matrix.tests != 'skip'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,10 @@ import groovy.json.JsonSlurper
 
 distFolder = "applications/electron/dist"
 releaseBranch = "master"
+// Attempt to detect that a PR is Jenkins-related, by looking-for 
+// the word "jenkins" (case insensitive) in PR branch name and/or 
+// the PR title
+jenkinsRelatedRegex = "(?i).*jenkins.*"
 
 pipeline {
     agent none
@@ -17,6 +21,18 @@ pipeline {
     }
     stages {
         stage('Build') {
+            // only proceed when merging on the release branch or if the 
+            // PR seems Jenkins-related
+            when {
+                anyOf {
+                    expression { 
+                        env.CHANGE_BRANCH ==~ /($releaseBranch|$jenkinsRelatedRegex)/ 
+                    }
+                    expression {
+                        env.CHANGE_TITLE ==~ /$jenkinsRelatedRegex/
+                    }
+                }
+            }
             parallel {
                 stage('Create Linux Installer') {
                     agent {
@@ -108,6 +124,18 @@ spec:
             }
         }
         stage('Sign and Upload') {
+            // only proceed when merging on the release branch or if the 
+            // PR seems Jenkins-related
+            when {
+                anyOf {
+                    expression { 
+                        env.CHANGE_BRANCH ==~ /($releaseBranch|$jenkinsRelatedRegex)/ 
+                    }
+                    expression {
+                        env.CHANGE_TITLE ==~ /$jenkinsRelatedRegex/
+                    }
+                }
+            }
             parallel {
                 stage('Upload Linux') {
                     agent any


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
See this [related proposal (#148)](https://github.com/eclipse-theia/theia-blueprint/issues/148)
    
What this PR does:
- enhance our GH workflow to generate Blueprint packages for our supported operating systems and run our test suite on them.
- only run Jenkins CI when merging on master or when we have reasonable suspicion(1) that the PR is related to Jenkins configuration changes. This will let us detect Jenkins update issues without having to merge to master first.
  -  technically the CI step still runs, but it will successfully exit almost immediately for most PRs. The `when` condition is used in `Jenkinsfile` to inhibit running the `Build` and `Sign and Upload` pipelines stages.
    
This will save a lot of CI time and insure Jenkins executor are available when we really need them: when we merge to master and want new packages generated, signed and uploaded.
    
(1) Currently, a heuristic is used: when the word "jenkins" (case does not matter) appears in the PR title or PR branch name, we assume that the PR is related to Jenkins and so it's valuable to run Jenkins CI on it, like before this PR. 

Note: a slight change in the Jenkins multi-branch pipeline configuration (from server web UI) was necessary for this to work. So far, we had one pipeline branch configured, triggered by either a merge to master or a PR branch change. In order for the PR's git branch name to be programmatically visible from  the`Jenkinsfile`, it was necessary to split these into 2 separate pipelines branch configuration, each one "watching" for a single thing (master branch, PR-related branch).
Ref: https://issues.jenkins.io/browse/JENKINS-7554

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
This could be a bit tricky to fully test before merging. In theory one could create several PRs, based on this PR branch, testing all permutations of having `jenkins` or not in the PR branch name and PR title. 

A simpler way : 
- look at the Jenkins CI step of this PR and confirm that it fully runs (both branch name and PR title contain `jenkins`, so that's what's expected)
  -  [Jenkins log](https://ci.eclipse.org/theia/job/Theia%20PRs/view/change-requests/job/PR-143/59/consoleFull)
- I created a test PR based on this PR's branch. The branch name and the PR title are `jenkins`-free. Verify that the Jenkins CI step was "streamlined" - it reports success but the log shows that it immediately bailed, e.g. `Stage "Create Linux Installer" skipped due to when conditional` 
   - PR: #149
   - [Jenkins log](https://ci.eclipse.org/theia/job/Theia%20PRs/view/change-requests/job/PR-149/1/console) . Look-for `Stage "Build" skipped due to when conditional`, `Stage "Create Linux Installer" skipped due to when conditional` and so on.
- also confirm that the GH actions run, and pass, and now include running our test suite.


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

