### PR TITLE
test: remove 'eclipse keymaps' from test

### DIFF
--- a/applications/electron/test/app.spec.js
+++ b/applications/electron/test/app.spec.js
@@ -126,7 +126,6 @@ describe("Theia App", function() {
     );
 
     // Exemplary check a few extensions
-    expect(extensionNames).to.include("Eclipse Keymap");
     expect(extensionNames).to.include("Debugger for Java");
     expect(extensionNames).to.include("TypeScript Language Basics (built-in)");
   });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes: #123

The pull-request removes the leftover assertion in the test-case to verify that `eclipse keymaps` is in fact present as a built-in extension. Since #140 the extension was removed but the test-case was no updated leading to the test suite failing.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. `yarn`
2. `(cd applications/electron && yarn package:preview)`
3. `(cd applications/electron && yarn test)`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

