### PR TITLE
Fixed test after removing Eclipse key bindings

### DIFF
--- a/applications/electron/test/app.spec.js
+++ b/applications/electron/test/app.spec.js
@@ -126,7 +126,6 @@ describe("Theia App", function() {
     );
 
     // Exemplary check a few extensions
-    expect(extensionNames).to.include("Eclipse Keymap");
     expect(extensionNames).to.include("Debugger for Java");
     expect(extensionNames).to.include("TypeScript Language Basics (built-in)");
   });


### PR DESCRIPTION
fixed #123

Signed-off-by: Jonas Helming <jhelming@eclipsesource.com>

#### What it does
Removes a check in the test whether the Eclipse key bindings are present. We removed them on purpose see #123

#### How to test
Build should run without test failures

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

