### PR TITLE
[CI] follow-up: fix Jenkins CI when merging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,8 +25,11 @@ pipeline {
             // PR seems Jenkins-related
             when {
                 anyOf {
+                    expression {
+                        env.GIT_BRANCH == /$releaseBranch/
+                    }
                     expression { 
-                        env.CHANGE_BRANCH ==~ /($releaseBranch|$jenkinsRelatedRegex)/ 
+                        env.CHANGE_BRANCH ==~ /$jenkinsRelatedRegex/ 
                     }
                     expression {
                         env.CHANGE_TITLE ==~ /$jenkinsRelatedRegex/
@@ -128,8 +131,11 @@ spec:
             // PR seems Jenkins-related
             when {
                 anyOf {
+                    expression {
+                        env.GIT_BRANCH == /$releaseBranch/
+                    }
                     expression { 
-                        env.CHANGE_BRANCH ==~ /($releaseBranch|$jenkinsRelatedRegex)/ 
+                        env.CHANGE_BRANCH ==~ /$jenkinsRelatedRegex/ 
                     }
                     expression {
                         env.CHANGE_TITLE ==~ /$jenkinsRelatedRegex/


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This is a follow-up to #143. After merging, I noticed that
Jenkins CI run was unexpectedly streamlined:
https://ci.eclipse.org/theia/job/Theia2/job/master/5/console

Looking at that log, it seems the environment available from
Jenkinsfile is a bit different, when merging vs when it's a PR.
Variable "env.CHANGE_BRANCH" is not set when merging,
so the "when" conditions did not work as expected.

Looking at a recent log for master, it seems "env.GIT_BRANCH"
is set and has correct value, so let's try using that instead.
log: https://ci.eclipse.org/theia/job/Theia2/job/master/4/consoleFull

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Make sure CI passes as expected. For the "merging to master" part, other than double-checking the change, I think we will need to merge to confirm that this works.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

