### PR TITLE
Auto-Updater may fail for signed electron apps #116

### DIFF
--- a/applications/electron/electron-builder.yml
+++ b/applications/electron/electron-builder.yml
@@ -37,6 +37,7 @@ mac:
   darkModeSupport: true
   target:
     - dmg
+    - zip
   publish:
     provider: generic
     url: "https://download.eclipse.org/theia/latest/macos"

--- a/applications/electron/package.json
+++ b/applications/electron/package.json
@@ -79,6 +79,8 @@
   },
   "devDependencies": {
     "@theia/cli": "1.17.1",
+    "@types/js-yaml": "^3.12.0",
+    "@types/yargs": "^17.0.2",
     "@wdio/cli": "^6.10.2",
     "@wdio/local-runner": "^6.10.2",
     "@wdio/mocha-framework": "^6.8.0",
@@ -89,10 +91,13 @@
     "electron-builder": "^22.8.0",
     "electron-chromedriver": "9.0.0",
     "electron-mocha": "^9.3.2",
+    "js-yaml": "^3.12.0",
     "mocha": "^8.2.1",
     "rimraf": "^2.7.1",
+    "ts-node": "^10.0.0",
     "wdio-chromedriver-service": "^6.0.4",
-    "webdriverio": "^6.10.2"
+    "webdriverio": "^6.10.2",
+    "yargs": "^17.0.1"
   },
   "scripts": {
     "prepare": "yarn build && yarn download:plugins",
@@ -106,6 +111,7 @@
     "package": "yarn clean:dist && electron-builder -c.mac.identity=null --publish never",
     "deploy": "yarn clean:dist && electron-builder -c.mac.identity=null --publish always",
     "package:preview": "yarn clean:dist && electron-builder --dir",
+    "update:checksum": "ts-node scripts/update-checksum.ts",
     "download:plugins": "theia download:plugins",
     "test": "mocha --timeout 60000 \"./test/*.spec.js\""
   },

--- a/applications/electron/scripts/update-checksum.ts
+++ b/applications/electron/scripts/update-checksum.ts
@@ -1,0 +1,106 @@
+/********************************************************************************
+ * Copyright (C) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as jsyaml from 'js-yaml';
+import * as path from 'path';
+import { hideBin } from 'yargs/helpers';
+import yargs from 'yargs/yargs';
+
+
+const argv = yargs(hideBin(process.argv))
+    .option('executable', { alias: 'e', type: 'string', default: 'TheiaBlueprint.AppImage', desription: 'The executable for which the checksum needs to be updated' })
+    .option('yaml', { alias: 'y', type: 'string', default: 'latest-linux.yml', desription: 'The yaml file where the checksum needs to be updated' })
+    .version(false)
+    .wrap(120)
+    .parseSync();
+
+execute();
+
+async function execute(): Promise<void> {
+    const executable = argv.executable;
+    const yaml = argv.yaml;
+
+    const executablePath = path.resolve(
+        __dirname,
+        '../dist/',
+        executable
+    );
+
+    const yamlPath = path.resolve(
+        __dirname,
+        '../dist/',
+        yaml
+    );
+
+    console.log('Exe: ' + executablePath + '; Yaml: ' + yamlPath)
+
+    const hash = await hashFile(executablePath, 'sha512', 'base64', {});
+    const size = fs.statSync(executablePath).size
+
+    const yamlContents: string = fs.readFileSync(yamlPath, { encoding: 'utf8' })
+    const latestYaml: any = jsyaml.safeLoad(yamlContents);
+    latestYaml.sha512 = hash;
+    latestYaml.path = updatedPath(latestYaml.path, latestYaml.version)
+    for (const file of latestYaml.files) {
+        file.sha512 = hash;
+        file.size = size;
+        file.url = updatedPath(file.url, latestYaml.version)
+    }
+
+    //line width -1 to avoid adding >- on long strings like a hash
+    const newYamlContents = jsyaml.dump(latestYaml, { lineWidth: -1 });
+    fs.writeFileSync(yamlPath, newYamlContents);
+}
+
+function hashFile(file: fs.PathLike, algorithm = 'sha512', encoding: BufferEncoding = 'base64', options: string | {
+    flags?: string;
+    encoding?: BufferEncoding;
+    fd?: number;
+    mode?: number;
+    autoClose?: boolean;
+    emitClose?: boolean;
+    start?: number;
+    end?: number;
+    highWaterMark?: number;
+}): Promise<any> {
+    return new Promise((resolve, reject) => {
+        const hash = crypto.createHash(algorithm);
+        hash.on('error', reject).setEncoding(encoding);
+        fs.createReadStream(
+            file,
+            Object.assign({}, options, {
+                highWaterMark: 1024 * 1024,
+            })
+        )
+            .on('error', reject)
+            .on('end', () => {
+                hash.end();
+                resolve(hash.read());
+            })
+            .pipe(
+                hash,
+                {
+                    end: false,
+                }
+            );
+    });
+}
+
+function updatedPath(path: string, version: string): string {
+    const extensionIndex = path.lastIndexOf('.');
+    return path.substring(0, extensionIndex) + '-' + version + path.substring(extensionIndex);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -828,6 +828,18 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.6.1.tgz#118511f316e2e87ee4294761868e254d3da47960"
+  integrity sha512-DX3Z+T5dt1ockmPdobJS/FAsQPW4V4SrWEhD2iYQT2Cb2tQsiMnYxrcUH9By/Z3B+v0S5LMBkQtV/XOBbpLEOg==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@develar/schema-utils@~2.6.5":
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/@develar/schema-utils/-/schema-utils-2.6.5.tgz#3ece22c5838402419a6e0425f85742b961d9b6c6"
@@ -1809,6 +1821,26 @@
     moment "2.24.0"
     valid-filename "^2.0.1"
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+
 "@types/base64-arraybuffer@0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@types/base64-arraybuffer/-/base64-arraybuffer-0.1.0.tgz#739eea0a974d13ae831f96d97d882ceb0b187543"
@@ -2027,6 +2059,11 @@
   integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
   dependencies:
     "@types/istanbul-lib-report" "*"
+
+"@types/js-yaml@^3.12.0":
+  version "3.12.7"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.7.tgz#330c5d97a3500e9c903210d6e49f02964af04a0e"
+  integrity sha512-S6+8JAYTE1qdsc9HMVsfY7+SgSuUU/Tp6TYTmITW0PZxiyIMvol3Gy//y69Wkhs0ti4py5qgR3uZH6uz/DNzJQ==
 
 "@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.6", "@types/json-schema@^7.0.7":
   version "7.0.7"
@@ -2428,6 +2465,13 @@
   version "15.0.12"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.12.tgz#6234ce3e3e3fa32c5db301a170f96a599c960d74"
   integrity sha512-f+fD/fQAo3BCbCDlrUpznF1A5Zp9rB0noS5vnoormHSIPFKL0Z2DcUJ3Gxp5ytH4uLRNxy7AwYUC9exZzqGMAw==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^17.0.2":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.2.tgz#8fb2e0f4cdc7ab2a1a570106e56533f31225b584"
+  integrity sha512-JhZ+pNdKMfB0rXauaDlrIvm+U7V4m03PPOSVoPS66z8gf+G4Z/UW8UlrVIj2MRQOBzuoEvYtjS0bqYwnpZaS9Q==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -2880,6 +2924,11 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
+acorn-walk@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.1.1.tgz#3ddab7f84e4a7e2313f6c414c5b7dac85f4e3ebc"
+  integrity sha512-FbJdceMlPHEAWJOILDk1fXD8lnTlEIWFkqtfk+MvmL5q/qlHfN7GEHcsFZWt/Tea9jRNPWUZG4G976nqAAmU9w==
+
 acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
@@ -3144,6 +3193,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -4645,6 +4699,11 @@ create-error-class@^3.0.0:
   integrity sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=
   dependencies:
     capture-stack-trace "^1.0.0"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-spawn-async@^2.1.1:
   version "2.2.5"
@@ -7700,7 +7759,7 @@ js-yaml@3.14.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.14.1:
+js-yaml@^3.12.0, js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -8328,6 +8387,11 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
@@ -11812,6 +11876,24 @@ ts-md5@^1.2.2:
   resolved "https://registry.yarnpkg.com/ts-md5/-/ts-md5-1.2.7.tgz#b76471fc2fd38f0502441f6c3b9494ed04537401"
   integrity sha512-emODogvKGWi1KO1l9c6YxLMBn6CEH3VrH5mVPIyOtxBG52BvV4jP3GWz6bOZCz61nLgBc3ffQYE4+EHfCD+V7w==
 
+ts-node@^10.0.0:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.2.1.tgz#4cc93bea0a7aba2179497e65bb08ddfc198b3ab5"
+  integrity sha512-hCnyOyuGmD5wHleOQX6NIjJtYVIO8bPP8F2acWkB4W06wdlkgyvJtubO/I9NkI88hCFECbsEgoLc0VNkYmcSfw==
+  dependencies:
+    "@cspotcode/source-map-support" "0.6.1"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    yn "3.1.1"
+
 tsconfig-paths@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
@@ -12786,6 +12868,19 @@ yargs@^16.0.3, yargs@^16.1.1:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
+yargs@^17.0.1:
+  version "17.1.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.1.1.tgz#c2a8091564bdb196f7c0a67c1d12e5b85b8067ba"
+  integrity sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
+
 yargs@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
@@ -12821,6 +12916,11 @@ yauzl@^2.10.0, yauzl@^2.4.2:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
#### What it does
This PR addresses the updates on windows and mac.

For Windows the issue is that the eclipse code signing changes the checksum. During build the checksum is computed before the code signign and saved in the latest.yaml (https://download.eclipse.org/theia/latest/windows/latest.yml) which is used for the update process. This checksum needs to take the signing process into account. 
Furthermore the electron-updater has an issue with non-unique file-names for the installer. We are using TheiaBlueprint.exe as the file-name (to have stable download links without the need to update the download page on every release). During the update process this leads to the point that Theia Blueprint is uninstalled but then the new version is not installed. This can be addressed by including the version in the filename in latest.yaml. 

For Mac the updater tries to download the changes as a zip. Currently we only provide the .dmg so we need to build the zip as well. This may be changed in applications/electron/electron-builder.yml 

For the windows fix this PR brings a script to update the yaml file (applications/electron/scripts/update-checksum.ts). This recomputes the checksum and also adds the version to the file name. This script is then used during the "Sign and Upload Windows" step on windows. 
In order to execute the script we use a similar kubernetes agent definition as during the Linux build and also mount the required volumes for updloading to download.eclipse.org. After uploading the TheiaBlueprint.exe we also create a soft link to TheiaBlueprint-version.exe so that file is found for updates.

#### How to test
Testing is a bit tricky. 
The update-checksum.ts may be tested on any platform locally. 
Build the blueprint installers. 
Then open the latest.yaml file for your platform, copy the checksum for verification and change it. 
Then execute the script using 
`yarn electron update:checksum -e ${executable} -y ${yaml}`
while replacing the paths. This should lead to the same checksum as was used before and an updated path including the version number. 

The changes related to publishing have not been fully tested yet. 
I have a test-build including some dummy steps here: https://ci.eclipse.org/theia/job/Theia%20PRs/view/change-requests/job/PR-129/11/
There I archived the windows results including the yaml update: https://ci.eclipse.org/theia/job/Theia%20PRs/view/change-requests/job/PR-129/11/artifact/applications/electron/dist/
And I was checking whether the new agent may still communivate with download.eclipse.org (here listing a directory): https://ci.eclipse.org/theia/job/Theia%20PRs/view/change-requests/job/PR-129/11/execution/node/237/log/

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

