### PR TITLE
Auto-Updater may fail for signed electron apps #116

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -222,7 +222,7 @@ spec:
                         container('jnlp') {
                             script {
                                 uploadInstaller('windows')
-                                linkInstaller('windows', 'TheiaBlueprint', 'exe')
+                                copyInstaller('windows', 'TheiaBlueprint', 'exe')
                             }
                         }
                     }
@@ -316,12 +316,12 @@ def uploadInstaller(String platform) {
     }
 }
 
-def linkInstaller(String platform, String installer, String extension) {
+def copyInstaller(String platform, String installer, String extension) {
     if (env.BRANCH_NAME == releaseBranch) {
         def packageJSON = readJSON file: "package.json"
         String version = "${packageJSON.version}"
         sshagent(['projects-storage.eclipse.org-bot-ssh']) {
-            sh "ssh genie.theia@projects-storage.eclipse.org ln -s /home/data/httpd/download.eclipse.org/theia/latest/${platform}/${installer}.${extension} /home/data/httpd/download.eclipse.org/theia/latest/${platform}/${installer}-${version}.${extension}"
+            sh "ssh genie.theia@projects-storage.eclipse.org cp /home/data/httpd/download.eclipse.org/theia/latest/${platform}/${installer}.${extension} /home/data/httpd/download.eclipse.org/theia/latest/${platform}/${installer}-${version}.${extension}"
         }
     } else {
         echo "Skipped copying installer for branch ${env.BRANCH_NAME}"


### PR DESCRIPTION
#### What it does
Soft linking does not seem to work. While https://download.eclipse.org/theia/latest/windows/ shows the TheiaBlueprint-1.17.1.exe installer, the download does not work. So let's copy the installer instead. 

As this is only needed in https://download.eclipse.org/theia/latest we only duplicate the windows installer once. 

closes #116 

#### How to test


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

