### PR TITLE
builtin: exclude `microsoft-authentication`

### DIFF
--- a/applications/electron/package.json
+++ b/applications/electron/package.json
@@ -125,6 +125,7 @@
     "vscjava.vscode-java-dependency": "https://open-vsx.org/api/vscjava/vscode-java-dependency/0.16.0/file/vscjava.vscode-java-dependency-0.16.0.vsix"
   },
   "theiaPluginsExcludeIds": [
-    "vscode.extension-editing"
+    "vscode.extension-editing",
+    "vscode.microsoft-authentication"
   ]
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The commit adds `vscode.microsoft-authentication` in the list of builtins to exclude from the bundled application since it is not
required or wanted by default. The extension is used to perform preference syncing to microsoft services.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Confirm that the `vscode-microsoft-authentication` plugin is skipped and not included in the final application.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

