### PR TITLE
[Updater] Allow to inspect logs on error

### DIFF
--- a/theia-extensions/theia-blueprint-updater/src/common/updater/theia-updater.ts
+++ b/theia-extensions/theia-blueprint-updater/src/common/updater/theia-updater.ts
@@ -25,8 +25,14 @@ export interface TheiaUpdater extends JsonRpcServer<TheiaUpdaterClient> {
 }
 
 export const TheiaUpdaterClient = Symbol('TheiaUpdaterClient');
+
+export interface UpdaterError {
+    message: string;
+    errorLogPath?: string;
+}
+
 export interface TheiaUpdaterClient {
     updateAvailable(available: boolean, startupCheck: boolean): void;
     notifyReadyToInstall(): void;
-    reportError(error: string): void;
+    reportError(error: UpdaterError): void;
 }

--- a/theia-extensions/theia-blueprint-updater/src/electron-main/update/theia-updater-impl.ts
+++ b/theia-extensions/theia-blueprint-updater/src/electron-main/update/theia-updater-impl.ts
@@ -62,7 +62,8 @@ export class TheiaUpdaterImpl implements TheiaUpdater, ElectronMainApplicationCo
         });
 
         autoUpdater.on('error', (err: unknown) => {
-            this.clients.forEach(c => c.reportError('Error during update'));
+            const errorLogPath = autoUpdater.logger.transports.file.getFile().path;
+            this.clients.forEach(c => c.reportError({ message: 'An error has occurred while attempting to update.', errorLogPath }));
         });
     }
 


### PR DESCRIPTION
#### What it does
Add an action to the error notification that allows the user to see the log file with the full error message.

The path to the error log is retrieved from the logger that was used to record the error. The path must be given as part of the error object for the action button to appear.

Fixes #161 

#### How to test
Start electron app `yarn electron start` and check for updates from Main Menu Bar -> File -> Settings -> Check for updates..
An error notification should show, with a message and a `View Error Log` button that opens the error log when clicked.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

