### PR TITLE
[CI] Replace decommissioned build.eclipse.org server in Jenkins config

### DIFF
--- a/applications/electron/electron-builder.yml
+++ b/applications/electron/electron-builder.yml
@@ -2,7 +2,7 @@ appId: eclipse.theia
 productName: TheiaBlueprint
 copyright: Copyright © 2020 Eclipse Foundation, Inc
 electronDist: ../../node_modules/electron/dist
-electronVersion: 9.3.2
+electronVersion: 9.4.4
 # Although it is generally not recommended to disable asar, it is required for Theia.
 # Enabling this leads to: process ERROR Error: spawn ENOTDIR
 # because binaries can not be executed from the asar archive.

--- a/applications/electron/scripts/after-pack.js
+++ b/applications/electron/scripts/after-pack.js
@@ -22,12 +22,15 @@ const signFile = file => {
     const mode = stat.isFile() ? stat.mode : undefined;
 
     console.log(`Signing ${file}...`);
-    child_process.execFileSync(signCommand, [
+    child_process.spawnSync(signCommand, [
         path.basename(file),
         entitlements
     ], {
         cwd: path.dirname(file),
-        maxBuffer: 1024 * 10000
+        maxBuffer: 1024 * 10000,
+        env: process.env,
+        stdio: 'inherit',
+        encoding: 'utf-8'
     });
 
     if (mode) {
@@ -73,11 +76,14 @@ exports.default = async function(context) {
     childPaths.forEach(file => signFile(file, context.appOutDir));
 
     // Notarize app
-    child_process.execFileSync(notarizeCommand, [
+    child_process.spawnSync(notarizeCommand, [
         path.basename(appPath),
         context.packager.appInfo.info._configuration.appId
     ], {
         cwd: path.dirname(appPath),
-        maxBuffer: 1024 * 10000
+        maxBuffer: 1024 * 10000,
+        env: process.env,
+        stdio: 'inherit',
+        encoding: 'utf-8'
     });
 }

--- a/applications/electron/scripts/notarize.sh
+++ b/applications/electron/scripts/notarize.sh
@@ -22,7 +22,7 @@ rm -f "${INPUT}"
 REMOTE_NAME=${INPUT##*/}
 
 # notarize over ssh
-RESPONSE=$(ssh -q genie.theia@projects-storage.eclipse.org curl -X POST -F file=@"\"${REMOTE_NAME}\"" -F "'options={\"primaryBundleId\": \"${APP_ID}\", \"staple\": true};type=application/json'" http://172.30.206.146:8383/macos-notarization-service/notarize)
+RESPONSE=$(ssh -q genie.theia@projects-storage.eclipse.org curl -X POST -F file=@"\"${REMOTE_NAME}\"" -F "'options={\"primaryBundleId\": \"${APP_ID}\", \"staple\": true};type=application/json'" https://cbi.eclipse.org/macos/xcrun/notarize)
 
 # fund uuid and status
 [[ $RESPONSE =~ $UUID_REGEX ]]
@@ -33,8 +33,8 @@ STATUS=${BASH_REMATCH[1]}
 # poll progress
 echo "  Progress: $RESPONSE"
 while [[ $STATUS == 'IN_PROGRESS' ]]; do
-    sleep 1m
-    RESPONSE=$(ssh -q genie.theia@projects-storage.eclipse.org curl -s http://172.30.206.146:8383/macos-notarization-service/$UUID/status)
+    sleep 120
+    RESPONSE=$(ssh -q genie.theia@projects-storage.eclipse.org curl -s https://cbi.eclipse.org/macos/xcrun/${UUID}/status)
     [[ $RESPONSE =~ $STATUS_REGEX ]]
     STATUS=${BASH_REMATCH[1]}
     echo "  Progress: $RESPONSE"
@@ -46,7 +46,7 @@ if [[ $STATUS != 'COMPLETE' ]]; then
 fi
 
 # download stapled result
-ssh -q genie.theia@projects-storage.eclipse.org curl -o "\"stapled-${REMOTE_NAME}\"" http://172.30.206.146:8383/macos-notarization-service/${UUID}/download
+ssh -q genie.theia@projects-storage.eclipse.org curl -o "\"stapled-${REMOTE_NAME}\"" https://cbi.eclipse.org/macos/xcrun/${UUID}/download
 
 # copy stapled file back from server
 scp -T -p genie.theia@projects-storage.eclipse.org:"\"./stapled-${REMOTE_NAME}\"" "${INPUT}"

--- a/applications/electron/scripts/sign.sh
+++ b/applications/electron/scripts/sign.sh
@@ -23,7 +23,8 @@ scp -p "${ENTITLEMENTS}" genie.theia@projects-storage.eclipse.org:./entitlements
 REMOTE_NAME=${INPUT##*/}
 
 # sign over ssh
-ssh -q genie.theia@projects-storage.eclipse.org curl -o "\"signed-${REMOTE_NAME}\"" -F file=@"\"${REMOTE_NAME}\"" -F entitlements=@entitlements.plist http://build.eclipse.org:31338/macsign.php
+# https://wiki.eclipse.org/IT_Infrastructure_Doc#Web_service
+ssh -q genie.theia@projects-storage.eclipse.org curl -f -o "\"signed-${REMOTE_NAME}\"" -F file=@"\"${REMOTE_NAME}\"" -F entitlements=@entitlements.plist https://cbi.eclipse.org/macos/codesign/sign
 
 # copy signed file back from server
 scp -T -p genie.theia@projects-storage.eclipse.org:"\"./signed-${REMOTE_NAME}\"" "${INPUT}"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
We use `build.eclipse.org` in our JenkinsFile and elsewhere. Let's try updating it to the suggested replacement server and hope this does the trick.

We also used a non-standard server for notarization: updated too.

more about the server decommission: 
https://wiki.eclipse.org/IT_Infrastructure_Doc#Web_service
https://www.eclipse.org/lists/eclipse.org-committers/msg01318.html
https://blogs.eclipse.org/post/denis-roy/bye-bye-build-end-era
https://bugs.eclipse.org/bugs/show_bug.cgi?id=565644

Also update URL of MacOS notarization service, in the few places
where we use the service, as per the documented example:
https://wiki.eclipse.org/IT_Infrastructure_Doc#macOS_Notarization

Use fail-fast option of curl, since this permits to immediately
detect if there's an issue with the macOS signing service, the
first time it's used.

E.g.:

ssh -q genie.theia@projects-storage.eclipse.org curl -f -o '"signed-ffmpeg.node"' -F 'file=@"ffmpeg.node"' -F entitlements=@entitlements.plist https://cbi.eclipse.org/macos/codesign/sign
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 36314    0     0  100 36314      0   571k --:--:-- --:--:-- --:--:--  571k
curl: (22) The requested URL returned error: 403

Replace child_process.execFileSync() by process.spawnSync() for both signing
and notarizing, so we can see related logs in real-time.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
For the signing and notarization, we can partially test through CI (Jenkins), but the final step for both signing and notarizing  is only taken when on the main branch, i.e.for merged PRs. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

