### PR TITLE
[Jenkins] [next] [mac] disable signing

### DIFF
--- a/next/Jenkinsfile
+++ b/next/Jenkinsfile
@@ -12,9 +12,6 @@ pipeline {
         timeout(time: 5, unit: 'HOURS')
         disableConcurrentBuilds()
     }
-    environment {
-        BLUEPRINT_JENKINS_CI = 'true'
-    }
     stages {
         stage('Build') {
             parallel {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
In `next/Jenkinsfile`, we set environment variable `BLUEPRINT_JENKINS_CI`. It's then used in the `electron-builder` post-packaging [script](https://github.com/eclipse-theia/theia-blueprint/blob/master/applications/electron/scripts/after-pack.js#L43) as part of a [test](https://github.com/eclipse-theia/theia-blueprint/blob/master/applications/electron/scripts/after-pack.js#L55) to determine if we should proceed with signing and notarization. 

I believe it should not for `next` CI, since we do not publish the resulting packages. So we probably do not want `BLUEPRINT_JENKINS_CI` set.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
I think we will need to merge to properly test this change. The CI this PR will go through will still set the environment variable, and so will not be representative of what we get when running a `next` cron build.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

