### PR TITLE
Have a way to not show Blueprint welcome screen

### DIFF
--- a/theia-extensions/theia-blueprint-product/src/browser/style/index.css
+++ b/theia-extensions/theia-blueprint-product/src/browser/style/index.css
@@ -46,6 +46,12 @@
     padding: 20px;
 }
 
+.gs-preference {
+    margin-top: 20px;
+    align-items: center;
+    display: flex;
+}
+
 .ad-logo {
     background-image: var(--theia-branding-logo);
     background-position: center center;

--- a/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-frontend-module.ts
+++ b/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-frontend-module.ts
@@ -16,7 +16,7 @@
 
 import '../../src/browser/style/index.css';
 
-import { FrontendApplicationContribution, WidgetFactory, bindViewContribution } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, WidgetFactory, bindViewContribution, PreferenceContribution } from '@theia/core/lib/browser';
 
 import { AboutDialog } from '@theia/core/lib/browser/about-dialog';
 import { CommandContribution } from '@theia/core/lib/common/command';
@@ -27,6 +27,7 @@ import { TheiaBlueprintAboutDialog } from './theia-blueprint-about-dialog';
 import { TheiaBlueprintContribution } from './theia-blueprint-contribution';
 import { TheiaBlueprintGettingStartedContribution } from './theia-blueprint-getting-started-contribution';
 import { TheiaBlueprintGettingStartedWidget } from './theia-blueprint-getting-started-widget';
+import { theiaBlueprintPreferenceSchema } from './theia-blueprint-preferences';
 
 export default new ContainerModule((bind, _unbind, isBound, rebind) => {
     bindViewContribution(bind, TheiaBlueprintGettingStartedContribution);
@@ -46,4 +47,6 @@ export default new ContainerModule((bind, _unbind, isBound, rebind) => {
     [CommandContribution, MenuContribution].forEach(serviceIdentifier =>
         bind(serviceIdentifier).toService(TheiaBlueprintContribution)
     );
+
+    bind(PreferenceContribution).toConstantValue({ schema: theiaBlueprintPreferenceSchema });
 });

--- a/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-contribution.ts
+++ b/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-contribution.ts
@@ -14,18 +14,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { AbstractViewContribution, FrontendApplication, FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { AbstractViewContribution, FrontendApplication, FrontendApplicationContribution, PreferenceService } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
 
 import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
 import { GettingStartedWidget } from '@theia/getting-started/lib/browser/getting-started-widget';
 import { TheiaBlueprintGettingStartedWidget } from './theia-blueprint-getting-started-widget';
+import { BlueprintPreferences } from './theia-blueprint-preferences';
 
 @injectable()
 export class TheiaBlueprintGettingStartedContribution extends AbstractViewContribution<TheiaBlueprintGettingStartedWidget> implements FrontendApplicationContribution {
 
     @inject(FrontendApplicationStateService)
     protected readonly stateService: FrontendApplicationStateService;
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
 
     constructor() {
         super({
@@ -39,7 +43,12 @@ export class TheiaBlueprintGettingStartedContribution extends AbstractViewContri
 
     async onStart(app: FrontendApplication): Promise<void> {
         this.stateService.reachedState('ready').then(
-            () => this.openView({ reveal: true })
+            () => this.preferenceService.ready.then(() => {
+                const showWelcomePage: boolean = this.preferenceService.get(BlueprintPreferences.alwaysShowWelcomePage, true);
+                if (showWelcomePage) {
+                    this.openView({ reveal: true });
+                }
+            })
         );
     }
 }

--- a/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-preferences.ts
+++ b/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-preferences.ts
@@ -1,0 +1,31 @@
+/********************************************************************************
+ * Copyright (C) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { PreferenceSchema } from '@theia/core/lib/common/preferences/preference-schema';
+export namespace BlueprintPreferences {
+    export const alwaysShowWelcomePage = 'blueprint.alwaysShowWelcomePage';
+}
+
+export const theiaBlueprintPreferenceSchema: PreferenceSchema = {
+    'type': 'object',
+    'properties': {
+        'blueprint.alwaysShowWelcomePage': {
+            type: 'boolean',
+            description: 'Show Welcome Page after every start of the application.',
+            default: true
+        }
+    }
+};


### PR DESCRIPTION
#### What it does
* adds preference whether to always show the welcome page
* check preference from getting started contribution
* add checkbox on welcome screen and sync with preference

Fixes #185

#### How to test
Build and test the setting from preferences and from welcome page.
Test that settings are synced between welcome page and preferences. 

Please note that when the checkbox get unchecked and the welcome page was not closed, it will get restored just like any other view. So in order to test this, the welcome page needs to be closed between reloads. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

