### PR TITLE
Run yarn upgrade during next build

### DIFF
--- a/next/Jenkinsfile
+++ b/next/Jenkinsfile
@@ -144,9 +144,20 @@ def buildNext(boolean runTests) {
         }
     }
 
-    echo "Updating versions to next"
+    echo "Updating theia versions to next"
     sh "yarn update:next"
-        try {
+    try {
+        sh(script: 'yarn --force')
+    } catch(error) {
+        retry(MAX_RETRY) {
+            echo "yarn failed - Retrying"
+            sh(script: 'yarn --force')        
+        }
+    }
+
+    echo "Upgrading versions"
+    sh "yarn upgrade"
+    try {
         sh(script: 'yarn --force')
     } catch(error) {
         retry(MAX_RETRY) {


### PR DESCRIPTION
#### What it does
Recently we had build issues (on the Eclipse CI) after running `yarn upgrade`. 
This PR also runs `yarn upgrade` during our nightly `next` build. This should help to identify version ranges that are too broad earlier. 

#### How to test
I think it needs to be executed on the CI for testing. 
I've did some testing here: https://ci.eclipse.org/theia/job/theia-next/job/jf%252Fnext/

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

