### PR TITLE
Welcome page tab not marked as active when focused #198

### DIFF
--- a/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-contribution.ts
+++ b/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-contribution.ts
@@ -46,7 +46,7 @@ export class TheiaBlueprintGettingStartedContribution extends AbstractViewContri
             () => this.preferenceService.ready.then(() => {
                 const showWelcomePage: boolean = this.preferenceService.get(BlueprintPreferences.alwaysShowWelcomePage, true);
                 if (showWelcomePage) {
-                    this.openView({ reveal: true });
+                    this.openView({ reveal: true, activate: true });
                 }
             })
         );

--- a/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-widget.tsx
+++ b/theia-extensions/theia-blueprint-product/src/browser/theia-blueprint-getting-started-widget.tsx
@@ -21,7 +21,7 @@ import { renderDocumentation, renderDownloads, renderSourceCode, renderTickets, 
 import { GettingStartedWidget } from '@theia/getting-started/lib/browser/getting-started-widget';
 import { VSXEnvironment } from '@theia/vsx-registry/lib/common/vsx-environment';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
-import { PreferenceService } from '@theia/core/lib/browser';
+import { Message, PreferenceService } from '@theia/core/lib/browser';
 import { BlueprintPreferences } from './theia-blueprint-preferences';
 import { DisposableCollection } from '@theia/core';
 
@@ -47,6 +47,14 @@ export class TheiaBlueprintGettingStartedWidget extends GettingStartedWidget {
         this.vscodeApiVersion = await this.environment.getVscodeApiVersion();
         await this.preferenceService.ready;
         this.update();
+    }
+
+    protected onActivateRequest(msg: Message): void {
+        super.onActivateRequest(msg);
+        const htmlElement = document.getElementById('alwaysShowWelcomePage');
+        if (htmlElement) {
+            htmlElement.focus();
+        }
     }
 
     protected render(): React.ReactNode {


### PR DESCRIPTION
#### What it does
* open getting start view with activate request
* set focus to always show welcome page checkbox when activated

Fixes #198

#### How to test
Build blueprint and check whether the welcome page tab is shown as active when focused (see STR in https://github.com/eclipse-theia/theia-blueprint/issues/198)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

