### PR TITLE
Eclipse CI build issues (Python version) #208

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,15 @@
 # .github/workflows/publish-builder-img.yml
 # It can be triggered manually from the GitHub project page. 
 
+# We still want Ubuntu 18.04 LTS compatibility, which is based on stretch
+# -> install newer python version manually
 FROM node:12.19.0-stretch
-RUN apt-get update && apt-get install -y libxkbfile-dev libsecret-1-dev
+RUN apt-get update && apt-get install -y libxkbfile-dev libsecret-1-dev && \
+    cd /tmp && \
+    wget https://www.python.org/ftp/python/3.6.15/Python-3.6.15.tar.xz && \
+    tar xvf Python-3.6.15.tar.xz && \
+    cd Python-3.6.15 && \
+    ./configure --enable-optimizations --enable-loadable-sqlite-extensions && \
+    make -j 8 && \
+    make altinstall && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.6 1


### PR DESCRIPTION
Install the required python version in the stretch docker image used for
building for linux manually. Since we want to support Ubuntu 18.04 we
should still build with stretch.

Fixes #208 (python part)

#### How to test
It possible to test via building the docker image locally (may take some time)
`docker build -t my-blueprint-builder .`
and then run the blueprint build locally with this image:
```
docker run --rm -ti \
 --env-file <(env | grep -iE 'DEBUG|NODE_|ELECTRON_|YARN_|NPM_|CI|CIRCLE|TRAVIS_TAG|TRAVIS|TRAVIS_REPO_|TRAVIS_BUILD_|TRAVIS_BRANCH|TRAVIS_PULL_REQUEST_|APPVEYOR_|CSC_|GH_|GITHUB_|BT_|AWS_|STRIP|BUILD_') \
 --env ELECTRON_CACHE="/root/.cache/electron" \
 --env ELECTRON_BUILDER_CACHE="/root/.cache/electron-builder" \
 -v ${PWD}:/project \
 -v ${PWD##*/}-node-modules:/project/node_modules \
 --entrypoint /bin/bash \
my-blueprint-builder

cd /project
yarn && yarn electron package
```

However I think it is easier to review this and merge so that it can be tested on the CI. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

