### PR TITLE
Align used engines with Theia

### DIFF
--- a/applications/electron/package.json
+++ b/applications/electron/package.json
@@ -16,8 +16,8 @@
     "url": "git+https://github.com/eclipse-theia/theia-blueprint.git"
   },
   "engines": {
-    "yarn": "1.0.x || >=1.2.1",
-    "node": ">=12.14.1 <13"
+    "yarn": ">=1.7.0 <2",
+    "node": ">=12.14.1"
   },
   "theia": {
     "target": "electron",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "url": "git+https://github.com/eclipse-theia/theia-blueprint.git"
   },
   "engines": {
-    "yarn": "1.0.x || >=1.2.1",
-    "node": ">=12.14.1 <13"
+    "yarn": ">=1.7.0 <2",
+    "node": ">=12.14.1"
   },
   "devDependencies": {
     "@theia/cli": "1.23.0",


### PR DESCRIPTION
#### What it does
Align used engines with Theia Main Repository
* do not force node 12 (will be EOL soon)
* adapt yarn constraint

Theia Links:
https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites
https://github.com/eclipse-theia/theia/blob/6d67d664bd3f679fca68be51d06d360a115decb2/package.json#L5

#### How to test
Building should still work. I've tested locally with node 12 and 14.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

