### PR TITLE
Clarify update dialogs

### DIFF
--- a/theia-extensions/theia-blueprint-updater/src/electron-browser/updater/theia-updater-frontend-contribution.ts
+++ b/theia-extensions/theia-blueprint-updater/src/electron-browser/updater/theia-updater-frontend-contribution.ts
@@ -193,7 +193,7 @@ export class TheiaUpdaterFrontendContribution implements CommandContribution, Me
     }
 
     protected async handleDownloadUpdate(): Promise<void> {
-        const answer = await this.messageService.info('Updates found, do you want to download the update?', 'No', 'Yes', 'Never');
+        const answer = await this.messageService.info('Updates found, do you want to update?', 'No', 'Yes', 'Never');
         if (answer === 'Never') {
             this.preferenceService.set('updates.reportOnStart', false, PreferenceScope.User);
             return;
@@ -223,7 +223,7 @@ export class TheiaUpdaterFrontendContribution implements CommandContribution, Me
             this.progress.report({ work: { done: 1, total: 1 } });
             this.stopProgress();
         }
-        const answer = await this.messageService.info('Ready to update. Do you want to update now? (This will restart the application)', 'No', 'Yes');
+        const answer = await this.messageService.info('An update has been downloaded and will be automatically installed on exit. Do you want to restart now?', 'No', 'Yes');
         if (answer === 'Yes') {
             this.updater.onRestartToUpdateRequested();
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Previously, the update dialogs gave the impression that a downloaded update wouldn't get installed if answering 'No' in the second dialog. Since this isn't the case, make it clear in the message that the update will get installed on application exit and that the question is whether to restart now or not.

Below screenshots show the new texts:

![updates found](https://user-images.githubusercontent.com/95412924/164508180-3bd21fed-cbe1-4553-b734-a4e7f9e3cb4b.png)

![restart now](https://user-images.githubusercontent.com/95412924/164508204-03e9f4f4-3d8a-43d6-b989-2add55133f6b.png)

Fixes #212

Contributed by STMicroelectronics
Signed-off-by: Erik LUNDIN <erik.lundin@st.com>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
The old messages can easily be seen with a version of Theia Blueprint that isn't the latest (otherwise no update dialogs will show). To see the new messages, the application has to be tricked that there is a new update available. I found out how to create a fake `app-update.yml` and set up a simple HTTP server to serve the update metadata and a fake appimage file, but since the commit is only changing the texts of two strings, it might be overkill to do this.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)