### PR TITLE
Fix electron store version, Add sleep between retries

### DIFF
--- a/next/Jenkinsfile
+++ b/next/Jenkinsfile
@@ -58,8 +58,10 @@ spec:
                     }
                     steps {
                         container('theia-dev') {
-                            script {
-                                buildNext(false)
+                            withCredentials([string(credentialsId: "github-bot-token", variable: 'GITHUB_TOKEN')]) {
+                                script {
+                                    buildNext(false, 1200)
+                                }
                             }
                         }
                     }
@@ -75,7 +77,7 @@ spec:
                     }
                     steps {
                         script {
-                            buildNext(false)
+                            buildNext(false, 60)
                         }
                     }
                     post {
@@ -91,7 +93,7 @@ spec:
                     steps {
                         script {
                             sh "npm config set msvs_version 2017"
-                            buildNext(true)
+                            buildNext(true, 60)
                         }
                     }
                     post {
@@ -119,7 +121,7 @@ spec:
     }
 }
 
-def buildNext(boolean runTests) {
+def buildNext(boolean runTests, int sleepBetweenRetries) {
     int MAX_RETRY = 3
 
     checkout scm
@@ -140,6 +142,7 @@ def buildNext(boolean runTests) {
         sh(script: 'yarn --frozen-lockfile --force')
     } catch(error) {
         retry(MAX_RETRY) {
+            sleep(sleepBetweenRetries)
             echo "yarn failed - Retrying"
             sh(script: 'yarn --frozen-lockfile --force')        
         }
@@ -151,6 +154,7 @@ def buildNext(boolean runTests) {
         sh(script: 'yarn --force')
     } catch(error) {
         retry(MAX_RETRY) {
+            sleep(sleepBetweenRetries)
             echo "yarn failed - Retrying"
             sh(script: 'yarn --force')        
         }
@@ -162,6 +166,7 @@ def buildNext(boolean runTests) {
         sh(script: 'yarn --force')
     } catch(error) {
         retry(MAX_RETRY) {
+            sleep(sleepBetweenRetries)
             echo "yarn failed - Retrying"
             sh(script: 'yarn --force')        
         }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "theia-extensions/*"
   ],
   "resolutions": {
-      "**/multer": "1.4.4-lts.1"
+      "**/multer": "1.4.4-lts.1",
+      "**/electron-store": "8.0.1"
   }
 }


### PR DESCRIPTION
#### What it does
Currently the next build on Jenkins fails after running `yarn upgrade`. 
This commit sets a resolution for `electron-store` to the currently used version. 
Once we do our next dependency upgrade we should investigate this in more detail. 

Besides that change this commit adds a sleep between retries. 
What we see often for the Linux build on Jenkins are failures when npm packages download content from github. 
This is probably due to rate-limits: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/912
Without the sleep the following builds will fail as well, since the limiting is still in place. I would like to see whether this will improve the situation for the next build. If so, I will make this change to the actual build as well. 

#### How to test
Regular build should still work. 
`yarn && yarn update:next && yarn && yarn upgrade && yarn` should work as well

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

