### PR TITLE
Update Build Dockerfile to Node 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 
 # We still want Ubuntu 18.04 LTS compatibility, which is based on stretch
 # -> install newer python version manually
-FROM node:12.19.0-stretch
+FROM node:14.19.3-stretch 
 RUN apt-get update && apt-get install -y libxkbfile-dev libsecret-1-dev && \
     cd /tmp && \
     wget https://www.python.org/ftp/python/3.6.15/Python-3.6.15.tar.xz && \


### PR DESCRIPTION
#### What it does
Updates our docker image for building on the eclipse ci to node 14, because this is the new Theia lower bound: https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites

#### How to test
Build the image locally and check whether building the image works. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

