### PR TITLE
Preinstall node-gyp on windows CI ( Jenkins )

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,6 +117,7 @@ spec:
                     steps {
                         script {
                             sh "npm config set msvs_version 2017"
+                            sh "npx node-gyp install 14.20.0"
                             buildInstaller(60)
                         }
                         stash name: 'win'

--- a/next/Jenkinsfile
+++ b/next/Jenkinsfile
@@ -93,6 +93,7 @@ spec:
                     steps {
                         script {
                             sh "npm config set msvs_version 2017"
+                            sh "npx node-gyp install 14.20.0"
                             buildNext(true, 60)
                         }
                     }


### PR DESCRIPTION
#### What it does
Windows and Mac Agents have been updated to use node 14.20.0

After the update we ran into the following issue on the windows agent:
https://github.com/nodejs/node-gyp/issues/2584#issuecomment-1064727363
This PR implements the workaround from the ticket

#### How to test
Check Jenkins Build result: https://ci.eclipse.org/theia/job/Theia%20PRs/job/PR-225/

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

