### PR TITLE
[Gitpod] update config to use node 14

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -13,7 +13,7 @@ RUN sudo apt-get update \
     && sudo apt-get install -y libx11-dev libxkbfile-dev \
     && sudo rm -rf /var/lib/apt/lists/*
 
-ENV NODE_VERSION="12.14.1"
+ENV NODE_VERSION="14"
 RUN bash -c ". .nvm/nvm.sh \
     && nvm install $NODE_VERSION \
     && nvm use $NODE_VERSION \

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,10 +12,10 @@ ports:
   - port: 9339 # Node.js debug port
     onOpen: ignore
 tasks:
-  - init: yarn --network-timeout 100000 && yarn electron package:preview && yarn electron package
+  - init: yarn --network-timeout 100000
     command: >
       jwm &
-      gp open /workspace/theia-blueprint/applications/electron/dist/latest-linux.yml
+      yarn electron start
 
 github:
   prebuilds:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->


#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
I find Gitpod is useful for quickly testing some PRs. ATM the node version
used is not compatible with Theia and so the build fails. This commit updates
the config to use node 14.

Also start the electron version of Blueprint when the build is done. It's
accessible from the Ports view (bottom bar) by selecting "open browser" 
in line "port 6080".


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
In the PR's CI steps, click on the "Details" link next to the `Gitpod` check. Confirm that the Blueprint build is successful in the Gitpod terminal.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

