### PR TITLE
launcher: remove logs from terminal when launching app

### DIFF
--- a/theia-extensions/theia-blueprint-launcher/package.json
+++ b/theia-extensions/theia-blueprint-launcher/package.json
@@ -19,7 +19,6 @@
   ],
   "dependencies": {
     "@theia/core": "1.35.0",
-    "@theia/plugin-ext": "1.35.0",
     "@vscode/sudo-prompt": "9.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
When starting the application from a terminal, using the installed `theia` command, keep the terminal clean and log all output to a log file. For now, the contents of the log file are overwritten on each application restart.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
#### If the launcher was never created
- Start the application from the AppImage and in the dialog that prompts you to create the launcher, select Yes.
- Open a terminal and type `theia`.
- The application should launch and no logs should be shown in the terminal from which it was started.
- The logs can be found in `~/.theia-blueprint/logs/launcher.log`

#### If the launcher was created before
- Replace the old AppImage with the new version containing the code from this PR. The path to the old file can be found in `~/theia-blueprint/globalStorage/blueprint-launcher/paths.json`. Alternatively, you can delete the paths.json file and open the AppImage. 
- Open a terminal and type `theia`.
- The application should launch and no logs should be shown in the terminal from which it was started.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

