### PR TITLE
Create Browser Application and Dockerfile #75

### DIFF
--- a/.github/workflows/publish-blueprint-img.yml
+++ b/.github/workflows/publish-blueprint-img.yml
@@ -1,0 +1,34 @@
+name: Publish Blueprint Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The image's tag
+        required: true
+        default: next
+
+jobs:
+  build:
+    name: Build and push blueprint image to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: browser.Dockerfile
+          push: true
+          tags: |
+            eclipsetheia/blueprint:${{ github.event.inputs.tag }}
+            eclipsetheia/blueprint:latest

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Documentation on how to package Theia as a Desktop Product may be found [here](h
 
 - Root level configures mono-repo build with lerna
 - `applications` groups the different app targets
-  - `electron` contains app to package, packaging configuration, and E2E tests for the electron target.
+  - `browser` contains a browser based version of Eclipse Theia Blueprint that may be packaged as a Docker image
+  - `electron` contains the electron app to package, packaging configuration, and E2E tests for the electron target.
 - `theia-extensions` groups the various custom theia extensions for Blueprint
   - `theia-blueprint-product` contains a Theia extension contributing the product branding (about dialogue and welcome page).
   - `theia-blueprint-updater` contains a Theia extension contributing the update mechanism and corresponding UI elements (based on the electron updater).
@@ -61,7 +62,7 @@ Documentation on how to package Theia as a Desktop Product may be found [here](h
 yarn
 ```
 
-### Package the Application
+### Package the Electron Application
 
 ```sh
 yarn electron package
@@ -69,7 +70,7 @@ yarn electron package
 
 The packaged application is located in `applications/electron/dist`.
 
-### Create a Preview Application (without packaging it)
+### Create a Preview Electron Application (without packaging it)
 
 ```sh
 yarn electron package:preview
@@ -77,7 +78,7 @@ yarn electron package:preview
 
 The packaged application is located in `applications/electron/dist`.
 
-### Running E2E Tests
+### Running E2E Tests on Electron
 
 The E2E tests basic UI tests of the actual application.
 This is done based on the preview of the packaged application.
@@ -86,6 +87,16 @@ This is done based on the preview of the packaged application.
 yarn electron package:preview
 yarn electron test
 ```
+
+### Running Browser app
+
+The browser app may be started with
+
+```sh
+yarn browser start
+```
+
+and connect to <http://localhost:3000/>
 
 ### Troubleshooting
 
@@ -98,7 +109,7 @@ Eclipse Theia Blueprint only packages existing functionality into a product and 
 
 ### Docker Build
 
-You can create a Docker Image for Blueprint with the following build command:
+You can create a Docker Image for Blueprint based on the browser app with the following build command:
 
 ```sh
 docker build -t theia-blueprint -f browser.Dockerfile .

--- a/README.md
+++ b/README.md
@@ -95,3 +95,19 @@ yarn electron test
 
 The features in Eclipse Theia Blueprint are based on Theia and the included extensions/plugins. For bugs in Theia please consider opening an issue in the [Theia project on Github](https://github.com/eclipse-theia/theia/issues/new/choose).
 Eclipse Theia Blueprint only packages existing functionality into a product and installers for the product. If you believe there is a mistake in packaging, something needs to be added to the packaging or the installers do not work properly, please [open an issue on Github](https://github.com/eclipse-theia/theia-blueprint/issues/new/choose) to let us know.
+
+### Docker Build
+
+You can create a Docker Image for Blueprint with the following build command:
+
+```sh
+docker build -t theia-blueprint -f browser.Dockerfile .
+```
+
+You may then run this with
+
+```sh
+docker run -p=3000:3000 --rm theia-blueprint
+```
+
+and connect to <http://localhost:3000/>

--- a/applications/browser/package.json
+++ b/applications/browser/package.json
@@ -97,24 +97,23 @@
     "rebuild": "theia rebuild:browser --cacheRoot ../..",
     "start": "yarn -s rebuild && theia start --plugins=local-dir:./plugins",
     "watch": "concurrently --kill-others -n tsc,bundle -c red,yellow \"tsc -b -w --preserveWatchOutput\" \"yarn -s watch:bundle\"",
-    "download:plugins": "theia download:plugins"
+    "download:plugins": "theia download:plugins --rate-limit=1"
   },
   "theiaPluginsDir": "plugins",
   "theiaPlugins": {
-    "vscode.git": "https://open-vsx.org/api/vscode/git/1.52.1/file/vscode.git-1.52.1.vsix",
+    "vscode.markdown-language-features": "https://open-vsx.org/api/vscode/markdown-language-features/1.39.2/file/vscode.markdown-language-features-1.39.2.vsix",
     "vscode-builtin-extensions-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.50.1/file/eclipse-theia.builtin-extension-pack-1.50.1.vsix",
+    "vscode.typescript": "https://open-vsx.org/api/vscode/typescript/1.62.3/file/vscode.typescript-1.62.3.vsix",
+    "vscode.typescript-language-features": "https://open-vsx.org/api/vscode/typescript-language-features/1.62.3/file/vscode.typescript-language-features-1.62.3.vsix",
     "redhat.java": "https://open-vsx.org/api/redhat/java/0.73.0/file/redhat.java-0.73.0.vsix",
     "vscjava.vscode-java-debug": "https://open-vsx.org/api/vscjava/vscode-java-debug/0.30.0/file/vscjava.vscode-java-debug-0.30.0.vsix",
     "vscjava.vscode-java-test": "https://open-vsx.org/api/vscjava/vscode-java-test/0.26.1/file/vscjava.vscode-java-test-0.26.1.vsix",
     "vscjava.vscode-maven": "https://open-vsx.org/api/vscjava/vscode-maven/0.21.2/file/vscjava.vscode-maven-0.21.2.vsix",
-    "vscjava.vscode-java-dependency": "https://open-vsx.org/api/vscjava/vscode-java-dependency/0.16.0/file/vscjava.vscode-java-dependency-0.16.0.vsix",
-    "redhat.vscode-xml": "https://open-vsx.org/api/redhat/vscode-xml/0.20.0/file/redhat.vscode-xml-0.20.0.vsix"
+    "vscjava.vscode-java-dependency": "https://open-vsx.org/api/vscjava/vscode-java-dependency/0.16.0/file/vscjava.vscode-java-dependency-0.16.0.vsix"
   },
   "theiaPluginsExcludeIds": [
     "ms-vscode.js-debug-companion",
     "vscode.extension-editing",
-    "vscode.microsoft-authentication",
-    "vscode.html-language-features",
     "vscode.git",
     "vscode.git-ui",
     "vscode.github",

--- a/applications/browser/package.json
+++ b/applications/browser/package.json
@@ -82,7 +82,6 @@
     "@theia/vsx-registry": "1.35.0",
     "@theia/workspace": "1.35.0",
     "fs-extra": "^9.0.1",
-    "theia-blueprint-updater": "1.35.0",
     "theia-blueprint-product": "1.35.0"
   },
   "devDependencies": {

--- a/applications/browser/package.json
+++ b/applications/browser/package.json
@@ -1,10 +1,9 @@
 {
   "private": true,
-  "name": "theia-blueprint",
-  "description": "Eclipse Theia blueprint product",
+  "name": "theia-blueprint-browser",
+  "description": "Eclipse Theia blueprint browser product",
   "productName": "Theia Blueprint",
   "version": "1.35.0",
-  "main": "scripts/theia-electron-main.js",
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "author": "Eclipse Theia <theia-dev@eclipse.org>",
   "homepage": "https://github.com/eclipse-theia/theia-blueprint#readme",
@@ -20,12 +19,12 @@
     "node": ">=12.14.1"
   },
   "theia": {
-    "target": "electron",
     "frontend": {
       "config": {
         "applicationName": "Theia Blueprint",
         "preferences": {
-          "toolbar.showToolbar": true
+          "toolbar.showToolbar": true,
+          "files.enableTrash": false
         }
       }
     },
@@ -49,7 +48,6 @@
     "@theia/debug": "1.35.0",
     "@theia/editor": "1.35.0",
     "@theia/editor-preview": "1.35.0",
-    "@theia/electron": "1.35.0",
     "@theia/external-terminal": "1.35.0",
     "@theia/file-search": "1.35.0",
     "@theia/filesystem": "1.35.0",
@@ -85,65 +83,38 @@
     "@theia/workspace": "1.35.0",
     "fs-extra": "^9.0.1",
     "theia-blueprint-updater": "1.35.0",
-    "theia-blueprint-product": "1.35.0",
-    "theia-blueprint-launcher": "1.35.0"
+    "theia-blueprint-product": "1.35.0"
   },
   "devDependencies": {
-    "@theia/cli": "1.35.0",
-    "@types/js-yaml": "^3.12.0",
-    "@types/yargs": "17.0.7",
-    "@wdio/cli": "^6.10.2",
-    "@wdio/local-runner": "^6.10.2",
-    "@wdio/mocha-framework": "^6.8.0",
-    "@wdio/spec-reporter": "^6.8.1",
-    "app-builder-lib": "22.10.5",
-    "chai": "^4.2.0",
-    "electron": "^15.5.7",
-    "electron-builder": "22.10.5",
-    "electron-chromedriver": "9.0.0",
-    "electron-mocha": "^9.3.2",
-    "js-yaml": "^3.12.0",
-    "mocha": "^8.2.1",
-    "rimraf": "^2.7.1",
-    "ts-node": "^10.0.0",
-    "wdio-chromedriver-service": "^6.0.4",
-    "webdriverio": "^6.10.2",
-    "yargs": "17.2.1",
-    "concurrently": "^3.5.0"
+    "@theia/cli": "1.35.0"
   },
   "scripts": {
     "prepare": "yarn build && yarn download:plugins",
     "clean": "theia clean && rimraf node_modules",
-    "clean:dist": "rimraf dist",
-    "build": "yarn -s bundle",
+    "build": "yarn -s compile && yarn -s bundle",
     "bundle": "theia build",
-    "rebuild": "theia rebuild:electron --cacheRoot ../..",
-    "watch": "concurrently -n compile,bundle \"theiaext watch --preserveWatchOutput\" \"theia build --watch --mode development\"",
-    "start": "yarn -s rebuild && electron scripts/theia-electron-main.js",
-    "start:debug": "yarn start --log-level=debug",
-    "package": "yarn clean:dist && electron-builder -c.mac.identity=null --publish never",
-    "deploy": "yarn clean:dist && electron-builder -c.mac.identity=null --publish always",
-    "package:preview": "yarn clean:dist && electron-builder -c.mac.identity=null --dir",
-    "update:checksum": "ts-node scripts/update-checksum.ts",
-    "update:next": "ts-node ../../scripts/update-theia-to-next.ts",
-    "download:plugins": "theia download:plugins",
-    "test": "mocha --timeout 60000 \"./test/*.spec.js\""
+    "compile": "tsc -b",
+    "rebuild": "theia rebuild:browser --cacheRoot ../..",
+    "start": "yarn -s rebuild && theia start --plugins=local-dir:./plugins",
+    "watch": "concurrently --kill-others -n tsc,bundle -c red,yellow \"tsc -b -w --preserveWatchOutput\" \"yarn -s watch:bundle\"",
+    "download:plugins": "theia download:plugins"
   },
   "theiaPluginsDir": "plugins",
   "theiaPlugins": {
-    "vscode.markdown-language-features": "https://open-vsx.org/api/vscode/markdown-language-features/1.39.2/file/vscode.markdown-language-features-1.39.2.vsix",
+    "vscode.git": "https://open-vsx.org/api/vscode/git/1.52.1/file/vscode.git-1.52.1.vsix",
     "vscode-builtin-extensions-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.50.1/file/eclipse-theia.builtin-extension-pack-1.50.1.vsix",
-    "vscode.typescript": "https://open-vsx.org/api/vscode/typescript/1.62.3/file/vscode.typescript-1.62.3.vsix",
-    "vscode.typescript-language-features": "https://open-vsx.org/api/vscode/typescript-language-features/1.62.3/file/vscode.typescript-language-features-1.62.3.vsix",
     "redhat.java": "https://open-vsx.org/api/redhat/java/0.73.0/file/redhat.java-0.73.0.vsix",
     "vscjava.vscode-java-debug": "https://open-vsx.org/api/vscjava/vscode-java-debug/0.30.0/file/vscjava.vscode-java-debug-0.30.0.vsix",
     "vscjava.vscode-java-test": "https://open-vsx.org/api/vscjava/vscode-java-test/0.26.1/file/vscjava.vscode-java-test-0.26.1.vsix",
     "vscjava.vscode-maven": "https://open-vsx.org/api/vscjava/vscode-maven/0.21.2/file/vscjava.vscode-maven-0.21.2.vsix",
-    "vscjava.vscode-java-dependency": "https://open-vsx.org/api/vscjava/vscode-java-dependency/0.16.0/file/vscjava.vscode-java-dependency-0.16.0.vsix"
+    "vscjava.vscode-java-dependency": "https://open-vsx.org/api/vscjava/vscode-java-dependency/0.16.0/file/vscjava.vscode-java-dependency-0.16.0.vsix",
+    "redhat.vscode-xml": "https://open-vsx.org/api/redhat/vscode-xml/0.20.0/file/redhat.vscode-xml-0.20.0.vsix"
   },
   "theiaPluginsExcludeIds": [
     "ms-vscode.js-debug-companion",
     "vscode.extension-editing",
+    "vscode.microsoft-authentication",
+    "vscode.html-language-features",
     "vscode.git",
     "vscode.git-ui",
     "vscode.github",

--- a/applications/browser/resources/preload.html
+++ b/applications/browser/resources/preload.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <style>
+        html,
+        body {
+            background-color: black;
+        }
+
+        .theia-preload {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            /* Above styles copied from https://github.com/eclipse-theia/theia/blob/5aeef6c0c683b4e91713ab736957e6655b486adc/packages/core/src/browser/style/index.css#L147-L151 */
+            /* Otherwise, there is a flickering when Theia's CSS loads. */
+
+            background-image: none;
+        }
+
+        .theia-preload::after {
+            /* remove default loading animation */
+            content: none;
+        }
+
+        .spinner-container {
+            display: flex;
+            flex-direction: center;
+            align-self: center;
+            justify-content: center;
+            height: 100vh;
+            width: 100vw;
+        }
+
+        .custom-spinner {
+            align-self: center;
+        }
+
+        .custom-spinner svg {
+            width: 16vw;
+            height: 16vh;
+            animation-delay: 0;
+            animation-duration: 2s;
+            animation-iteration-count: infinite;
+            animation-name: blueprint-spinner;
+            animation-timing-function: ease;
+        }
+
+        @keyframes blueprint-spinner {
+            0% {
+                filter: invert(49%) sepia(71%) saturate(5980%) hue-rotate(199deg) brightness(103%) contrast(101%);
+                transform: scale(1.0);
+            }
+
+            50% {
+                filter: invert(57%) sepia(52%) saturate(1900%) hue-rotate(160deg) brightness(100%) contrast(102%);
+                transform: scale(0.8);
+            }
+
+            100% {
+                filter: invert(49%) sepia(71%) saturate(5980%) hue-rotate(199deg) brightness(103%) contrast(101%);
+                transform: scale(1.0);
+            }
+        }
+    </style>
+</head>
+
+<body>
+    <div class='spinner-container'>
+        <div class='custom-spinner'>
+            <svg id="spinner" version="1.1" xmlns="http://www.w3.org/2000/svg"
+                xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" preserveAspectRatio="xMinYMin meet"
+                viewBox="0, 0, 1150, 540.6">
+                <g id="Layer_1" fill="#FFFFFF">
+                    <path
+                        d="M880.199,2.8 C1028.1,2.8 1147.9,122.6 1147.9,270.5 C1147.9,418.3 1028.1,538.2 880.2,538.2 L290.1,538.2 C269,538.2 251.9,521.1 251.9,500 C251.9,478.9 269,461.8 290.1,461.8 L427.6,461.8 C448.6,461.8 465.7,444.7 465.7,423.6 C465.7,402.5 448.6,385.4 427.6,385.4 L396.999,385.4 C375.9,385.4 358.8,368.3 358.8,347.2 C358.8,326.1 375.9,309 397,309 L488.703,309 C509.918,308.941 526.373,291.65 526.9,270.8 C526.9,249.7 509.8,232.6 488.7,232.6 L167.8,232.6 C146.7,232.6 129.6,215.5 129.6,194.4 C129.6,173.3 146.7,156.2 167.8,156.2 L404.604,156.2 C425.818,156.141 442.273,138.85 442.8,118 C442.8,96.9 425.7,79.8 404.6,79.8 L351.2,79.8 C330.1,79.8 313,62.7 313,41.6 C313,20.5 330.1,2.4 351.2,2.4 L880.199,2.8 z M837.4,92 L837.4,92 C755.2,92 688.7,158.6 688.7,240.7 L688.7,300.2 C688.7,382.4 755.2,448.9 837.4,448.9 C919.5,448.9 986.1,382.4 986.1,300.2 L986.1,240.7 C986.1,158.6 919.5,92 837.4,92 L837.4,92 z M888.2,232.6 C908,232.6 924.1,248.7 924.1,268.5 L924.1,273.1 C924.1,292.9 908,309 888.2,309 L776.6,309 C756.8,309 740.7,292.9 740.7,273.1 L740.7,268.5 C740.7,248.7 756.8,232.6 776.6,232.6 L888.2,232.6 z" />
+                    <path
+                        d="M170.1,461.8 C190,461.8 206,477.8 206,497.7 L206,502.3 C206,522.1 190,538.2 170.1,538.2 L38,538.2 C18.2,538.2 2.1,522.1 2.1,502.3 L2.1,497.7 C2.1,477.8 18.2,461.8 38,461.8 L170.1,461.8 z" />
+                    <path
+                        d="M231.3,3.4 C251.1,3.4 267.1,19.5 267.1,39.3 L267.1,44 C267.1,63.8 251.1,79.8 231.3,79.8 L83.8,79.8 C64,79.8 47.9,63.8 47.9,44 L47.9,39.3 C47.9,19.5 64,3.4 83.8,3.4 L231.3,3.4 z" />
+                    <path
+                        d="M277.1,309 C296.9,309 313,325.1 313,344.9 L313,349.5 C313,369.3 296.9,385.4 277.1,385.4 L196.1,385.4 C176.3,385.4 160.2,369.3 160.2,349.5 L160.2,344.9 C160.2,325.1 176.3,309 196.1,309 L277.1,309 z" />
+                </g>
+            </svg>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/applications/browser/tsconfig.json
+++ b/applications/browser/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "../../configs/base.tsconfig",
+    "include": [],
+    "compilerOptions": {
+      "composite": true
+    },
+    "references": [
+      {
+        "path": "../../theia-extensions/theia-blueprint-product"
+      }
+    ]
+}

--- a/applications/browser/webpack.config.js
+++ b/applications/browser/webpack.config.js
@@ -1,0 +1,17 @@
+/**
+ * This file can be edited to customize webpack configuration.
+ * To reset delete this file and rerun theia build again.
+ */
+// @ts-check
+const config = require('./gen-webpack.config.js');
+
+/**
+ * Expose bundled modules on window.theia.moduleName namespace, e.g.
+ * window['theia']['@theia/core/lib/common/uri'].
+ * Such syntax can be used by external code, for instance, for testing.
+config.module.rules.push({
+    test: /\.js$/,
+    loader: require.resolve('@theia/application-manager/lib/expose-loader')
+}); */
+
+module.exports = config;

--- a/applications/electron/package.json
+++ b/applications/electron/package.json
@@ -126,7 +126,7 @@
     "package:preview": "yarn clean:dist && electron-builder -c.mac.identity=null --dir",
     "update:checksum": "ts-node scripts/update-checksum.ts",
     "update:next": "ts-node ../../scripts/update-theia-to-next.ts",
-    "download:plugins": "theia download:plugins",
+    "download:plugins": "theia download:plugins --rate-limit=1",
     "test": "mocha --timeout 60000 \"./test/*.spec.js\""
   },
   "theiaPluginsDir": "plugins",

--- a/browser.Dockerfile
+++ b/browser.Dockerfile
@@ -1,0 +1,37 @@
+FROM node:16-bullseye as build-stage
+RUN apt-get update && apt-get install -y libxkbfile-dev libsecret-1-dev
+WORKDIR /home/theia
+COPY . .
+RUN yarn --pure-lockfile && \
+    yarn --production && \
+    yarn autoclean --init && \
+    echo *.ts >> .yarnclean && \
+    echo *.ts.map >> .yarnclean && \
+    echo *.spec.* >> .yarnclean && \
+    yarn autoclean --force && \
+    yarn cache clean
+
+FROM node:16-bullseye-slim as production-stage
+RUN adduser --system --group theia
+RUN chmod g+rw /home && \
+    mkdir -p /home/project && \
+    chown -R theia:theia /home/theia && \
+    chown -R theia:theia /home/project;
+RUN apt-get update && apt-get install -y wget apt-transport-https && \
+    wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /usr/share/keyrings/adoptium.asc && \
+    echo "deb [signed-by=/usr/share/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list && \
+    apt-get update && apt-get install -y git openssh-client openssh-server bash libsecret-1-0 temurin-17-jdk maven && \
+    apt-get purge -y wget && \
+    apt-get clean
+ENV HOME /home/theia
+WORKDIR /home/theia
+COPY --from=build-stage --chown=theia:theia /home/theia /home/theia
+EXPOSE 3000
+ENV SHELL=/bin/bash \
+    THEIA_DEFAULT_PLUGINS=local-dir:/home/theia/applications/browser/plugins
+ENV USE_LOCAL_GIT true
+USER theia
+
+WORKDIR /home/theia/applications/browser
+ENTRYPOINT [ "node", "/home/theia/applications/browser/src-gen/backend/main.js" ]
+CMD [ "/home/project", "--hostname=0.0.0.0" ]

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "watch": "lerna run --parallel watch",
     "test": "lerna run test",
     "electron": "yarn --cwd applications/electron",
+    "browser": "yarn --cwd applications/browser",
     "update:next": "ts-node scripts/update-theia-to-next.ts && lerna run update:next"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "yargs": "17.2.1"
   },
   "scripts": {
-    "prepare": "lerna run prepare",
+    "prepare": "lerna run prepare --concurrency 1",
     "lint": "lerna run lint",
     "lint:fix": "lerna run lint:fix",
     "clean": "lerna run clean && rimraf node_modules",

--- a/theia-extensions/theia-blueprint-product/package.json
+++ b/theia-extensions/theia-blueprint-product/package.json
@@ -17,7 +17,7 @@
   },
   "theiaExtensions": [
     {
-      "frontendElectron": "lib/browser/theia-blueprint-frontend-module",
+      "frontend": "lib/browser/theia-blueprint-frontend-module",
       "electronMain": "lib/electron-main/theia-blueprint-main-module",
       "backend": "lib/node/theia-blueprint-backend-module"
     }


### PR DESCRIPTION
#### What it does
* create a dedicated browser application
* adapt product so that frontend code is useable from browser app as well
* move electron:rebuild to laters stage to avoid conflicts between both applications
* Create Dockerfile with Github Workflow and adapt Readme

#### How to test
* Check whether electron based app is still working
* Test browser application with `yarn browser start`
* Test Dockerfile and image with instructions from Readme

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

