### PR TITLE
Docker improvements (Jenkins)

### DIFF
--- a/.github/workflows/publish-blueprint-img.yml
+++ b/.github/workflows/publish-blueprint-img.yml
@@ -22,6 +22,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to the Github Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
@@ -30,5 +37,8 @@ jobs:
           file: browser.Dockerfile
           push: true
           tags: |
-            eclipsetheia/blueprint:${{ github.event.inputs.tag }}
-            eclipsetheia/blueprint:latest
+            ghcr.io/${{ github.repository }}/blueprint:${{ github.event.inputs.tag }}
+            ghcr.io/${{ github.repository }}/blueprint:latest
+# Add below after repository was created
+            # eclipsetheia/blueprint:${{ github.event.inputs.tag }}
+            # eclipsetheia/blueprint:latest

--- a/.github/workflows/publish-builder-img.yml
+++ b/.github/workflows/publish-builder-img.yml
@@ -25,4 +25,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: eclipsetheia/theia-blueprint:latest
+          tags: eclipsetheia/theia-blueprint:builder

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ kind: Pod
 spec:
   containers:
   - name: theia-dev
-    image: eclipsetheia/theia-blueprint
+    image: eclipsetheia/theia-blueprint:builder
     command:
     - cat
     tty: true
@@ -176,7 +176,7 @@ kind: Pod
 spec:
   containers:
   - name: theia-dev
-    image: eclipsetheia/theia-blueprint
+    image: eclipsetheia/theia-blueprint:builder
     command:
     - cat
     tty: true

--- a/applications/browser/package.json
+++ b/applications/browser/package.json
@@ -22,6 +22,7 @@
     "frontend": {
       "config": {
         "applicationName": "Theia Blueprint",
+        "warnOnPotentiallyInsecureHostPattern": false,
         "preferences": {
           "toolbar.showToolbar": true,
           "files.enableTrash": false
@@ -30,6 +31,7 @@
     },
     "backend": {
       "config": {
+        "warnOnPotentiallyInsecureHostPattern": false,
         "startupTimeout": -1,
         "resolveSystemPlugins": false
       }

--- a/browser.Dockerfile
+++ b/browser.Dockerfile
@@ -1,8 +1,19 @@
+# Builder stage
 FROM node:16-bullseye as build-stage
+
+# install required tools to build the application
 RUN apt-get update && apt-get install -y libxkbfile-dev libsecret-1-dev
+
 WORKDIR /home/theia
+
+# Copy repository files
 COPY . .
-RUN yarn --pure-lockfile && \
+
+# Remove unnecesarry files for the browser application
+# Download plugins and build application production mode
+# Use yarn autoclean to remove unnecessary files from package dependencies
+RUN rm -rf .git applications/electron theia-extensions/theia-blueprint-launcher theia-extensions/theia-blueprint-updater && \
+    yarn --pure-lockfile && \
     yarn browser download:plugins && \
     yarn --production && \
     yarn autoclean --init && \
@@ -12,27 +23,48 @@ RUN yarn --pure-lockfile && \
     yarn autoclean --force && \
     yarn cache clean
 
+# Production stage uses a small base image
 FROM node:16-bullseye-slim as production-stage
+
+# Create theia user and directories
+# Application will be copied to /home/theia
+# Default workspace is located at /home/project
 RUN adduser --system --group theia
 RUN chmod g+rw /home && \
     mkdir -p /home/project && \
     chown -R theia:theia /home/theia && \
     chown -R theia:theia /home/project;
+
+# Install required tools for application: Temurin JDK, JDK, SSH, Bash, Maven
+# Node is already available in base image
 RUN apt-get update && apt-get install -y wget apt-transport-https && \
     wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /usr/share/keyrings/adoptium.asc && \
     echo "deb [signed-by=/usr/share/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list && \
     apt-get update && apt-get install -y git openssh-client openssh-server bash libsecret-1-0 temurin-17-jdk maven && \
     apt-get purge -y wget && \
     apt-get clean
+
 ENV HOME /home/theia
 WORKDIR /home/theia
+
+# Copy application from builder-stage
 COPY --from=build-stage --chown=theia:theia /home/theia /home/theia
+
 EXPOSE 3000
+
+# Specify default shell for Theia and the Built-In plugins directory
 ENV SHELL=/bin/bash \
     THEIA_DEFAULT_PLUGINS=local-dir:/home/theia/applications/browser/plugins
-ENV USE_LOCAL_GIT true
-USER theia
 
+# Use installed git instead of dugite
+ENV USE_LOCAL_GIT true
+
+# Swtich to Theia user
+USER theia
 WORKDIR /home/theia/applications/browser
+
+# Launch the backend application via node
 ENTRYPOINT [ "node", "/home/theia/applications/browser/src-gen/backend/main.js" ]
+
+# Arguments passed to the application
 CMD [ "/home/project", "--hostname=0.0.0.0" ]

--- a/next/Jenkinsfile
+++ b/next/Jenkinsfile
@@ -24,7 +24,7 @@ kind: Pod
 spec:
   containers:
   - name: theia-dev
-    image: eclipsetheia/theia-blueprint
+    image: eclipsetheia/theia-blueprint:builder
     command:
     - cat
     tty: true


### PR DESCRIPTION
#### What it does
* remove unnecessary packages from blueprint docker image
* publish to github container registry as well (see comment on #253)
* comment out dockerhub until repository is available
* adapt tags of builder image to be less confusing (see comment on #253)
* set warnOnPotentiallyInsecureHostPattern to false, so that adopters may override the host patterns. We keep the defaults, that don't trigger a warning. 
* add comments to browser.Dockerfile so that adopters may adjust this more easily

I've tested the publish step and the package is available here: https://github.com/eclipse-theia/theia-blueprint/pkgs/container/theia-blueprint%2Fblueprint

```
docker run -p=3000:3000 --rm ghcr.io/eclipse-theia/theia-blueprint/blueprint:1.35.0
```

New Builder image was created with this run: https://github.com/eclipse-theia/theia-blueprint/actions/runs/4500989413/jobs/7920817014

This builder image was used during verification on Jenkins: https://ci.eclipse.org/theia/job/Theia%20PRs/view/change-requests/job/PR-254/10/

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

