### PR TITLE
Update Jenkins Builder Image to Node 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,7 @@
 # .github/workflows/publish-builder-img.yml
 # It can be triggered manually from the GitHub project page. 
 
-# We still want Ubuntu 18.04 LTS compatibility, which is based on stretch
-# -> install newer python version manually
-FROM node:14.19.3-stretch 
-RUN apt-get update && apt-get install -y libxkbfile-dev libsecret-1-dev && \
-    cd /tmp && \
-    wget https://www.python.org/ftp/python/3.6.15/Python-3.6.15.tar.xz && \
-    tar xvf Python-3.6.15.tar.xz && \
-    cd Python-3.6.15 && \
-    ./configure --enable-optimizations --enable-loadable-sqlite-extensions && \
-    make -j 8 && \
-    make altinstall && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.6 1
+# We still want Ubuntu 20.04 LTS compatibility, which is based on bullseye
+# -> buster is old enough
+FROM node:16.14.2-buster
+RUN apt-get update && apt-get install -y libxkbfile-dev libsecret-1-dev python3


### PR DESCRIPTION
#### What it does
* also use python from package repository again

#### How to test
One way would be to build the image locally, start the container, and clone theia-blueprint in the container and build the next branch. This is currently failing on the CI. 

```
docker build -t eclipsetheia/theia-blueprint:local .
docker run --rm -it --entrypoint /bin/bash eclipsetheia/theia-blueprint:local

# inside container
cd /tmp
git clone https://github.com/eclipse-theia/theia-blueprint.git
cd theia-blueprint
git checkout -b next origin/next
yarn
yarn upgrade
yarn
yarn electron package:preview
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

