### PR TITLE
[CI] [Jenkins] Clean-up tmp files on Windows agent after CI run

### DIFF
--- a/cleanup/Jenkinsfile
+++ b/cleanup/Jenkinsfile
@@ -1,0 +1,63 @@
+import groovy.json.JsonSlurper
+
+pipeline {
+    agent none
+    options {
+        timeout(time: 1, unit: 'HOURS')
+        disableConcurrentBuilds()
+    }
+    stages {
+        stage('Cleanup') {
+            parallel {
+                stage('Cleanup Windows temp directory') {
+                    agent {
+                        label 'windows'
+                    }
+                    steps {
+                        script {
+                            cleanDirs('tmp/yarn', '\"%temp%\"', '(yarn--*)')
+                            cleanDirs('tmp/plugin-download', '\"%temp%\"', '(theia-plugin-download*)')
+                            cleanDirs('tmp/lighthouse', '\"%temp%\"', '(lighthouse.*)')
+                            cleanDir('appdata/local/electron', '\"%LocalAppData%\"\\electron\\Cache')
+                            cleanYarnCache('appdata/local/yarn', '\"%LocalAppData%\"\\Yarn\\Cache')
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+def cleanDirs(String label, String parent, String pattern) {
+    bat "echo \"Before ${label} Cleanup:\""
+
+    bat "FOR /D /R ${parent} %%i in ${pattern} do echo \"%%i\""
+    bat "FOR /D /R ${parent} %%i in ${pattern} do @rmdir /s /q \"%%i\""
+
+    bat "echo \"After ${label} Cleanup:\""
+
+    bat "FOR /D /R ${parent} %%i in ${pattern} do echo \"%%i\""
+}
+
+def cleanDir(String label, String parent) {
+    bat "echo \"Before ${label} Cleanup:\""
+
+    bat "FOR /D /R ${parent} %%i in (*) do echo \"%%i\""
+    bat "if exist ${parent} @rmdir /s /q ${parent}"
+
+    bat "echo \"After ${label} Cleanup:\""
+
+    bat "FOR /D /R ${parent} %%i in (*) do echo \"%%i\""
+}
+
+def cleanYarnCache(String label, String parent) {
+    bat "echo \"Before ${label} Cleanup:\""
+
+    bat "FOR /D /R ${parent} %%i in (*) do echo \"%%i\""
+    sh "yarn cache clean --all"
+
+    bat "echo \"After ${label} Cleanup:\""
+
+    bat "FOR /D /R ${parent} %%i in (*) do echo \"%%i\""
+}
+


### PR DESCRIPTION
#### What it does
Adds a build job that cleans up the windows temp directory (including some logs to see what is happening) regularly. 

We could either trigger the Job timer-based (e.g. once a week) or run it after certain build jobs. 

Contributed on behalf of STMicroelectronics

#### How to test
Can only be tested on Eclipse CI. 
I've set up a Job that currently runs from the branch atm: https://ci.eclipse.org/theia/job/Theia%20-%20Cleanup%20Build%20Nodes/job/jf%252Ftemp-cleanup/11/console
The Job is currently configured to run once a week. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

