### PR TITLE
A few tweaks to the new "cleanup" Jenkins file

### DIFF
--- a/cleanup/Jenkinsfile
+++ b/cleanup/Jenkinsfile
@@ -1,63 +1,74 @@
-import groovy.json.JsonSlurper
-
 pipeline {
-    agent none
+    agent {
+        label 'windows'
+    }
     options {
         timeout(time: 1, unit: 'HOURS')
         disableConcurrentBuilds()
     }
     stages {
-        stage('Cleanup') {
-            parallel {
-                stage('Cleanup Windows temp directory') {
-                    agent {
-                        label 'windows'
-                    }
-                    steps {
-                        script {
-                            cleanDirs('tmp/yarn', '\"%temp%\"', '(yarn--*)')
-                            cleanDirs('tmp/plugin-download', '\"%temp%\"', '(theia-plugin-download*)')
-                            cleanDirs('tmp/lighthouse', '\"%temp%\"', '(lighthouse.*)')
-                            cleanDir('appdata/local/electron', '\"%LocalAppData%\"\\electron\\Cache')
-                            cleanYarnCache('appdata/local/yarn', '\"%LocalAppData%\"\\Yarn\\Cache')
-                        }
-                    }
+        stage('Cleanup Windows temp directory') {
+            steps {
+                script {
+                    listTemp('before cleanup', '%temp%')
+                    cleanFiles('tmp/plugin-download', '%temp%', 'theia-plugin-download**')
+                    cleanDirs('tmp/yarn', '%temp%', 'yarn--**')
+                    cleanDirs('tmp/lighthouse', '%temp%', 'lighthouse.*')
+                    listTemp('after cleanup', '%temp%')
+                    cleanDir('appdata/local/electron', '\"%LocalAppData%\"\\electron\\Cache')
+                    cleanYarnCache('appdata/local/yarn')
                 }
             }
         }
     }
 }
 
-def cleanDirs(String label, String parent, String pattern) {
-    bat "echo \"Before ${label} Cleanup:\""
-
-    bat "FOR /D /R ${parent} %%i in ${pattern} do echo \"%%i\""
-    bat "FOR /D /R ${parent} %%i in ${pattern} do @rmdir /s /q \"%%i\""
-
-    bat "echo \"After ${label} Cleanup:\""
-
-    bat "FOR /D /R ${parent} %%i in ${pattern} do echo \"%%i\""
+Object listTemp(String label, String temp) {
+    echo "in listTemp():  ${label}"
+    bat "DIR ${temp}"
+    return
 }
 
-def cleanDir(String label, String parent) {
-    bat "echo \"Before ${label} Cleanup:\""
+Object cleanFiles(String label, String parent, String pattern) {
+    echo "in cleanFile() - clean: ${label} files"
+    echo "parent: ${parent}, pattern: ${pattern}"
+
+    // use "returnStatus" option to avoid an exception being thrown if no
+    // matching files are found, failing the pipeline
+    s = bat(
+            script: "FORFILES /p ${parent} /m ${pattern} /C \"cmd /c Del /q @file\"",
+            returnStatus: true
+        )
+    if (s != 0) {
+        echo "No ${pattern} file found... Good I guess"
+    }
+}
+
+Object cleanDirs(String label, String parent, String pattern) {
+    echo "Before ${label} Cleanup:"
+
+    bat "FOR /D /R ${parent} %%i in (${pattern}) do echo \"%%i\""
+    bat "FOR /D /R ${parent} %%i in (${pattern}) do @rmdir /s /q \"%%i\""
+
+    echo "After ${label} Cleanup:"
+    bat "FOR /D /R ${parent} %%i in (${pattern}) do echo \"%%i\""
+    return
+}
+
+Object cleanDir(String label, String parent) {
+    echo "Before ${label} Cleanup:"
 
     bat "FOR /D /R ${parent} %%i in (*) do echo \"%%i\""
     bat "if exist ${parent} @rmdir /s /q ${parent}"
 
-    bat "echo \"After ${label} Cleanup:\""
-
+    echo "After ${label} Cleanup:"
     bat "FOR /D /R ${parent} %%i in (*) do echo \"%%i\""
+    return
 }
 
-def cleanYarnCache(String label, String parent) {
-    bat "echo \"Before ${label} Cleanup:\""
-
-    bat "FOR /D /R ${parent} %%i in (*) do echo \"%%i\""
-    sh "yarn cache clean --all"
-
-    bat "echo \"After ${label} Cleanup:\""
-
-    bat "FOR /D /R ${parent} %%i in (*) do echo \"%%i\""
+Object cleanYarnCache(String label) {
+    echo "Cleaning-up: ${label}"
+    sh 'yarn cache clean --all'
+    return
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Looking at the [log of the first run](https://ci.eclipse.org/theia/job/Theia%20-%20Cleanup%20Build%20Nodes/job/master/1/consoleFull), I noticed that seemingly no `yarn--<random number>` or `theia-plugin-download<random identifier>` file were found or cleaned. It was confirmed in the Gitlab ticket that these two types of files are still present on the server.

In this PR, I adapt the pattern we use for those two file types.  I also handle the case of the "theia-plugin-download**" files differently, looking-for and deleting individual files that match the pattern rather than directories.

Finally I made misc little tweaks based in linter feedback.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
I think we will need to merge the PR in order for it to run on Jenkins?

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

