### PR TITLE
Remove timers import from node and use from Window instead #273

### DIFF
--- a/theia-extensions/theia-blueprint-updater/src/electron-browser/updater/theia-updater-frontend-contribution.ts
+++ b/theia-extensions/theia-blueprint-updater/src/electron-browser/updater/theia-updater-frontend-contribution.ts
@@ -30,7 +30,6 @@ import { TheiaUpdater, TheiaUpdaterClient, UpdaterError } from '../../common/upd
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { CommonMenus, OpenerService } from '@theia/core/lib/browser';
 import { ElectronMainMenuFactory } from '@theia/core/lib/electron-browser/menu/electron-main-menu-factory';
-import { setInterval, clearInterval } from 'timers';
 import URI from '@theia/core/lib/common/uri';
 import { URI as VSCodeURI } from 'vscode-uri';
 


### PR DESCRIPTION
#### What it does
Fixes #273 by removing imports from node. The required functions are available on `Window` as well.

https://developer.mozilla.org/en-US/docs/Web/API/setInterval
https://developer.mozilla.org/en-US/docs/Web/API/clearInterval

Contributed on behalf of STMicroelectronics

Signed-off-by: Johannes Faltermeier <jfaltermeier@eclipsesource.com>

#### How to test
1. First increase version in `applications/electron/package.json` to e.g. `1.39.1`
2. `yarn && yarn electron package`
3. Copy `applications/electron/dist` directory to some other location
4. Run `npx serve -d -u -p 5000` in the copied dist directory to serve this build as a potential update
5. Undo the change from step 1
6. Update the `url`s in `applications/electron/electron-builder.yml` to `http://localhost:5000`
7. Run `yarn && yarn electron package` again (this time building an app with version 1.39.0)
8. Start the built 1.39.0 application and check whether the update works again. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

