### PR TITLE
Follow-up: fix detection of production mac build

### DIFF
--- a/applications/electron/scripts/after-pack.js
+++ b/applications/electron/scripts/after-pack.js
@@ -42,7 +42,7 @@ const signFile = file => {
 exports.default = async function (context) {
     const running_ci = process.env.BLUEPRINT_JENKINS_CI === 'true';
     const releaseDryRun = process.env.BLUEPRINT_JENKINS_RELEASE_DRYRUN === 'true';
-    const branch = process.env.CHANGE_BRANCH;
+    const branch = process.env.BRANCH_NAME;
     const running_on_mac = context.packager.platform.name === 'mac';
     const appPath = path.resolve(context.appOutDir, `${context.packager.appInfo.productFilename}.app`);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
I noticed an issue after merging PR #272, looking at the [Jenkins build log](https://ci.eclipse.org/theia/job/Theia2/job/master/116/console). 
![image](https://github.com/eclipse-theia/theia-blueprint/assets/25749063/68b313a2-577d-4faf-82ff-ac4247b6816d)

To save build time, we only proceed with macos signing/notarising when it's detected that the current build is producing official blueprint packages. Unfortunately a little bug was introduced in https://github.com/eclipse-theia/theia-blueprint/pull/272 , that prevents this mechanism from working, resulting in an unsigned/un-notarised macos package \[1\]. 

This is the fix.

\[1\]: note: I killed the Jenkins build before if got far enough to potentially release a bad macos package.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Unfortunately I think we need to merge to be certain. But I think the fix is simple enough to be validated by looking at the Jenkins linked log above.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

