### PR TITLE
Introduce Update Channels #278

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -399,12 +399,12 @@ def uploadInstaller(String platform) {
         def packageJSON = readJSON file: "package.json"
         String version = "${packageJSON.version}"
         sshagent(['projects-storage.eclipse.org-bot-ssh']) {
-            sh "ssh genie.theia@projects-storage.eclipse.org rm -rf /home/data/httpd/download.eclipse.org/theia/ide/${version}/${platform}"
-            sh "ssh genie.theia@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/theia/ide/${version}/${platform}"
-            sh "scp ${distFolder}/*.* genie.theia@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/theia/ide/${version}/${platform}"
-            sh "ssh genie.theia@projects-storage.eclipse.org rm -rf /home/data/httpd/download.eclipse.org/theia/ide/latest/${platform}"
-            sh "ssh genie.theia@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/theia/ide/latest/${platform}"
-            sh "scp ${distFolder}/*.* genie.theia@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/theia/ide/latest/${platform}"
+            sh "ssh genie.theia@projects-storage.eclipse.org rm -rf /home/data/httpd/download.eclipse.org/theia/ide-preview/${version}/${platform}"
+            sh "ssh genie.theia@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/theia/ide-preview/${version}/${platform}"
+            sh "scp ${distFolder}/*.* genie.theia@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/theia/ide-preview/${version}/${platform}"
+            sh "ssh genie.theia@projects-storage.eclipse.org rm -rf /home/data/httpd/download.eclipse.org/theia/ide-preview/latest/${platform}"
+            sh "ssh genie.theia@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/theia/ide-preview/latest/${platform}"
+            sh "scp ${distFolder}/*.* genie.theia@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/theia/ide-preview/latest/${platform}"
         }
     } else {
         echo "Skipped upload for branch ${env.BRANCH_NAME}"
@@ -421,16 +421,16 @@ def copyInstallerAndUpdateLatestYml(String platform, String installer, String ex
         def packageJSON = readJSON file: "package.json"
         String version = "${packageJSON.version}"
         sshagent(['projects-storage.eclipse.org-bot-ssh']) {
-            sh "ssh genie.theia@projects-storage.eclipse.org cp /home/data/httpd/download.eclipse.org/theia/ide/latest/${platform}/${installer}.${extension} /home/data/httpd/download.eclipse.org/theia/ide/latest/${platform}/${installer}-${version}.${extension}"
-            sh "ssh genie.theia@projects-storage.eclipse.org cp /home/data/httpd/download.eclipse.org/theia/ide/${version}/${platform}/${installer}.${extension} /home/data/httpd/download.eclipse.org/theia/ide/${version}/${platform}/${installer}-${version}.${extension}"
-            sh "ssh genie.theia@projects-storage.eclipse.org cp /home/data/httpd/download.eclipse.org/theia/ide/latest/${platform}/${installer}.${extension}.blockmap /home/data/httpd/download.eclipse.org/theia/ide/latest/${platform}/${installer}-${version}.${extension}.blockmap"
-            sh "ssh genie.theia@projects-storage.eclipse.org cp /home/data/httpd/download.eclipse.org/theia/ide/${version}/${platform}/${installer}.${extension}.blockmap /home/data/httpd/download.eclipse.org/theia/ide/${version}/${platform}/${installer}-${version}.${extension}.blockmap"
+            sh "ssh genie.theia@projects-storage.eclipse.org cp /home/data/httpd/download.eclipse.org/theia/ide-preview/latest/${platform}/${installer}.${extension} /home/data/httpd/download.eclipse.org/theia/ide-preview/latest/${platform}/${installer}-${version}.${extension}"
+            sh "ssh genie.theia@projects-storage.eclipse.org cp /home/data/httpd/download.eclipse.org/theia/ide-preview/${version}/${platform}/${installer}.${extension} /home/data/httpd/download.eclipse.org/theia/ide-preview/${version}/${platform}/${installer}-${version}.${extension}"
+            sh "ssh genie.theia@projects-storage.eclipse.org cp /home/data/httpd/download.eclipse.org/theia/ide-preview/latest/${platform}/${installer}.${extension}.blockmap /home/data/httpd/download.eclipse.org/theia/ide-preview/latest/${platform}/${installer}-${version}.${extension}.blockmap"
+            sh "ssh genie.theia@projects-storage.eclipse.org cp /home/data/httpd/download.eclipse.org/theia/ide-preview/${version}/${platform}/${installer}.${extension}.blockmap /home/data/httpd/download.eclipse.org/theia/ide-preview/${version}/${platform}/${installer}-${version}.${extension}.blockmap"
         }
         if (UPDATABLE_VERSIONS.length() != 0) {
             for (oldVersion in UPDATABLE_VERSIONS.split(",")) {
                 sshagent(['projects-storage.eclipse.org-bot-ssh']) {
-                    sh "ssh genie.theia@projects-storage.eclipse.org rm -f /home/data/httpd/download.eclipse.org/theia/ide/${oldVersion}/${platform}/${yaml}"
-                    sh "ssh genie.theia@projects-storage.eclipse.org cp /home/data/httpd/download.eclipse.org/theia/ide/${version}/${platform}/${yaml} /home/data/httpd/download.eclipse.org/theia/ide/${oldVersion}/${platform}/${yaml}"
+                    sh "ssh genie.theia@projects-storage.eclipse.org rm -f /home/data/httpd/download.eclipse.org/theia/ide-preview/${oldVersion}/${platform}/${yaml}"
+                    sh "ssh genie.theia@projects-storage.eclipse.org cp /home/data/httpd/download.eclipse.org/theia/ide-preview/${version}/${platform}/${yaml} /home/data/httpd/download.eclipse.org/theia/ide-preview/${oldVersion}/${platform}/${yaml}"
                 }
             }
         } else {

--- a/releng/promote/Jenkinsfile
+++ b/releng/promote/Jenkinsfile
@@ -1,0 +1,78 @@
+/**
+ * This Jenkinsfile promotes a given version of the Theia IDE from /theia/ide-preview to /theia/ide
+ */
+
+/* groovylint-disable NestedBlockDepth */
+import groovy.json.JsonSlurper
+
+pipeline {
+    agent none
+    options {
+        timeout(time: 3, unit: 'HOURS')
+        disableConcurrentBuilds()
+    }
+    environment {
+    }
+    stages {
+
+       stage('Setup parameters') {
+            steps {
+                script { 
+                    properties([
+                        parameters([
+                            string(
+                                defaultValue: 'latest', 
+                                name: 'VERSION', 
+                                trim: true
+                            ),
+                            string(
+                                defaultValue: '1.41.0,1.42.1,1.43.0', 
+                                name: 'TOUPDATE', 
+                                trim: true
+                            )
+                        ])
+                    ])
+                }
+            }
+       }
+
+        stage('Promote') {
+            agent any
+            steps {
+                script {
+                    promote('linux', params.VERSION)
+                    promote('macos', params.VERSION)
+                    promote('windows', params.VERSION)
+
+                    // update latest.yaml on windows for differential updater
+                    updateLatestYaml('windows', params.VERSION, 'TheiaIDESetup', 'exe', 'latest.yml', params.TOUPDATE)
+                }
+            }
+        }
+    }
+}
+
+def promote(String platform, String version) {
+    sshagent(['projects-storage.eclipse.org-bot-ssh']) {
+        sh "ssh genie.theia@projects-storage.eclipse.org rm -rf /home/data/httpd/download.eclipse.org/theia/ide/${version}/${platform}"
+        sh "ssh genie.theia@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/theia/ide/${version}/${platform}"
+        sh "scp genie.theia@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/theia/ide-preview/${version}/${platform}/*.* genie.theia@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/theia/ide/${version}/${platform}"
+
+        sh "ssh genie.theia@projects-storage.eclipse.org rm -rf /home/data/httpd/download.eclipse.org/theia/ide/latest/${platform}"
+        sh "ssh genie.theia@projects-storage.eclipse.org mkdir -p /home/data/httpd/download.eclipse.org/theia/ide/latest/${platform}"
+        sh "scp genie.theia@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/theia/ide-preview/${version}/${platform}/*.* genie.theia@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/theia/ide/latest/${platform}"
+    }
+}
+
+def updateLatestYaml(String platform, String version, String installer, String extension, String yaml, String UPDATABLE_VERSIONS) {
+    if (UPDATABLE_VERSIONS.length() != 0) {
+        for (oldVersion in UPDATABLE_VERSIONS.split(",")) {
+            sshagent(['projects-storage.eclipse.org-bot-ssh']) {
+                sh "ssh genie.theia@projects-storage.eclipse.org rm -f /home/data/httpd/download.eclipse.org/theia/ide/${oldVersion}/${platform}/${yaml}"
+                sh "ssh genie.theia@projects-storage.eclipse.org cp /home/data/httpd/download.eclipse.org/theia/ide/${version}/${platform}/${yaml} /home/data/httpd/download.eclipse.org/theia/ide/${oldVersion}/${platform}/${yaml}"
+            }
+        }
+    } else {
+        echo "No updateable versions"
+    }
+}

--- a/theia-extensions/updater/src/common/updater/theia-updater.ts
+++ b/theia-extensions/updater/src/common/updater/theia-updater.ts
@@ -16,6 +16,7 @@ export interface TheiaUpdater extends JsonRpcServer<TheiaUpdaterClient> {
     downloadUpdate(): void;
     onRestartToUpdateRequested(): void;
     disconnectClient(client: TheiaUpdaterClient): void;
+    setUpdateChannel(channel: string): void;
 }
 
 export const TheiaUpdaterClient = Symbol('TheiaUpdaterClient');

--- a/theia-extensions/updater/src/electron-browser/updater/theia-updater-frontend-contribution.ts
+++ b/theia-extensions/updater/src/electron-browser/updater/theia-updater-frontend-contribution.ts
@@ -136,6 +136,13 @@ export class TheiaUpdaterFrontendContribution implements CommandContribution, Me
 
     @postConstruct()
     protected init(): void {
+        this.preferenceService.ready.then(() => this.updater.setUpdateChannel(this.preferenceService.get('updates.channel', 'stable')));
+        this.preferenceService.onPreferenceChanged(e => {
+            if (e.preferenceName === 'updates.channel') {
+                this.updater.setUpdateChannel(this.preferenceService.get('updates.channel', 'stable'));
+            }
+        });
+
         this.updaterClient.onUpdateAvailable(available => {
             if (available) {
                 this.handleDownloadUpdate();

--- a/theia-extensions/updater/src/electron-browser/updater/theia-updater-preferences.ts
+++ b/theia-extensions/updater/src/electron-browser/updater/theia-updater-preferences.ts
@@ -16,6 +16,11 @@ export const theiaUpdaterPreferenceSchema: PreferenceSchema = {
             type: 'boolean',
             description: 'Report available updates after application start.',
             default: true
-        }
+        },
+        'updates.channel': {
+            type: 'string',
+            enum: ['stable', 'preview'], // once we have a nightly/next build, we can add a third channel
+            default: 'stable'
+        },
     }
 };


### PR DESCRIPTION
#### What it does
The goal of this PR is to add a second update channel. 

Until now every commit was built and the result was pushed to https://download.eclipse.org/theia/ide/

With this PR we will instead push the results to https://download.eclipse.org/theia/ide-preview/
The ide-preview location may be used for testing the IDE before we promote it to https://download.eclipse.org/theia/ide/

For the promotion there will be a new Jenkinsfile in this PR that will be used to copy the results. 
This needs to be triggered manually on the build server then. 

Finally there is a new preference for selecting an update channel. 
The current options are `stable` (https://download.eclipse.org/theia/ide/ Released Theia Version, Theia IDE was tested before promotion) and `preview` (https://download.eclipse.org/theia/ide-preview/ Released Theia Versions, Used for testing before promotion to general public). We may add a third option for Theia Nightlies in the future (non-released nightly builds of Theia). 

Contributed on behalf of STMicroelectronics

#### How to test

##### Update channels

Testing the update channels requires some local adjustments. 
See the image below to check a valid file structure for local testing on linux.. This structure mimics our download.eclipse.org layout

* prepare sources for local testing by doing a workspace wide search and replace for "https://download.eclipse.org/theia/" with "http://localhost:5000/". This should update `electron-builder.yml` and `theia-updater-impl`. Please verify that the changes look sensible to you, meaning the resulting URLs look valid to you (no missing or additional "/" e.g.)
* build a "stable" realease with `yarn && yarn build:dev && yarn electron package`
* create a new directory somewhere on your hard drive. Within this directory, create two further directories "ide" and "ide-preview"
* within the ide directory create one directory called "latest" and one directory called "1.45.0" (Should be the version used in `applications/electron/package.json`)
* within those two directories, create a further directory based on your os: "windows", "macos", or "linux"
* Now copy the contents of "applications/electron/dist" inside these directories
* Now increment the patch part of the version in `applications/electron/package.json`, e.g. from 1.45.0 to 1.45.1
* Build a "preview" release with `yarn && yarn build:dev && yarn electron package`
* within the ide-preview directory create one directory called "latest" and one directory called "1.45.1" (Should be the updated version from `applications/electron/package.json`)
* within those two directories, create a further directory based on your os: "windows", "macos", or "linux"
* Now copy the contents of "applications/electron/dist" inside these directories
* From the directory containing the "ide" and "ide-preview" directories, run `npx serve -d -u -p 5000`. The output logs will have valuable information for verifying the channels. 
* Point your browser to http://localhost:5000/ to check if you can see the ide and ide-preview directories
* Now launch the "stable" installer/application (this is the one available in the ide directory)
* File -> Preferences -> Check for Updates...
* The logs of the `npx serve` should show three accesses to `/ide` (1st one is stable location that happens on startup of the application, 2nd one happens when the preference was reported from electron frontend to backend, 3rd one was out manual "Check for Updates...")

```
 HTTP  1/19/2024 2:35:23 PM ::1 GET /ide/latest/linux/latest-linux.yml?noCache=1hkguts90
 HTTP  1/19/2024 2:35:23 PM ::1 Returned 200 in 5 ms
 HTTP  1/19/2024 2:35:25 PM ::1 GET /ide/latest/linux/latest-linux.yml?noCache=1hkguttlg
 HTTP  1/19/2024 2:35:25 PM ::1 Returned 200 in 0 ms
 HTTP  1/19/2024 2:35:58 PM ::1 GET /ide/latest/linux/latest-linux.yml?noCache=1hkguuu1a
 HTTP  1/19/2024 2:35:58 PM ::1 Returned 200 in 1 ms
```
* Now go to the preferences and search for `updates.channel`. Update from `stable` to `preview`
* File -> Preferences -> Check for Updates...
* Select "No" to not install the updates. There should be one new log
```
 HTTP  1/19/2024 2:43:17 PM ::1 GET /ide-preview/latest/linux/latest-linux.yml?noCache=1hkgvcb62
 HTTP  1/19/2024 2:43:17 PM ::1 Returned 200 in 0 ms
```
* Now restart the IDE to check if the update is reported in startup automatically. This should create new logs like this (again stable is always checked on startup, only then we may update the preference)
```
 HTTP  1/19/2024 2:44:49 PM ::1 GET /ide/latest/linux/latest-linux.yml?noCache=1hkgvf48l
 HTTP  1/19/2024 2:44:49 PM ::1 Returned 200 in 0 ms
 HTTP  1/19/2024 2:44:50 PM ::1 GET /ide-preview/latest/linux/latest-linux.yml?noCache=1hkgvf5lh
 HTTP  1/19/2024 2:44:50 PM ::1 Returned 200 in 1 ms
```
* Install the update and continue manual testing

![ksnip_20240119-145339](https://github.com/eclipse-theia/theia-blueprint/assets/5889696/f59ed4a5-98a5-4298-8651-0eab26af44d8)

##### Build Jobs

The build jobs need to be tested on the Eclipse CI. I don't have local testing instructions. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

