### PR TITLE
Updated docker base image to node:18-bullseye in browser.Dockerfile

### DIFF
--- a/browser.Dockerfile
+++ b/browser.Dockerfile
@@ -1,5 +1,5 @@
 # Builder stage
-FROM node:16-bullseye as build-stage
+FROM node:18-bullseye as build-stage
 
 # install required tools to build the application
 RUN apt-get update && apt-get install -y libxkbfile-dev libsecret-1-dev
@@ -26,7 +26,7 @@ RUN yarn --pure-lockfile && \
     rm -r .git applications/electron theia-extensions/launcher theia-extensions/updater node_modules
 
 # Production stage uses a small base image
-FROM node:16-bullseye-slim as production-stage
+FROM node:18-bullseye-slim as production-stage
 
 # Create theia user and directories
 # Application will be copied to /home/theia


### PR DESCRIPTION
#### What it does

Resolves https://github.com/eclipse-theia/theia-blueprint/issues/345

`node:16-bullseye` seems outdated and resulted in the bug documented in the above issue.  It is not currently supported on the official list of node docker images: https://hub.docker.com/_/node

The issue at https://github.com/eclipse-theia/theia-blueprint/issues/345 was resolved even by changing to `node:18-bullseye` only in the `build-stage`, but presumably it should be already upgraded also in the `production-stage`, so this commit/PR also updates the production stage based image.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Following/repeating the instructions here: https://github.com/eclipse-theia/theia-blueprint/issues/345

1. `git clone https://github.com/eclipse-theia/theia-blueprint`
2. `cd theia-blueprint`
3. `docker build -t theia-ide -f browser.Dockerfile .` (like instructed [here](https://github.com/eclipse-theia/theia-blueprint#docker-build))
4. **Look for side-effects** in the usual testing manner for this project, or otherwise decide if to make this upgrade.  I am merely submitting the 'quick-fix' here for the `docker build` command failure documented in issue [#345](https://github.com/eclipse-theia/theia-blueprint/issues/345). But I am relying on the core development team to consider how and whether/when such an upgrade fits with the rest of the development process.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

