### PR TITLE
Update browser.Dockerfile

### DIFF
--- a/browser.Dockerfile
+++ b/browser.Dockerfile
@@ -23,7 +23,7 @@ RUN yarn --pure-lockfile && \
     echo *.spec.* >> .yarnclean && \
     yarn autoclean --force && \
     yarn cache clean && \
-    rm -r .git applications/electron theia-extensions/launcher theia-extensions/updater node_modules
+    rm -rf .git applications/electron theia-extensions/launcher theia-extensions/updater node_modules
 
 # Production stage uses a small base image
 FROM node:18-bullseye-slim as production-stage


### PR DESCRIPTION
Building the browser.Dockerfile fails at line 26 as the .git directory appears missing. With rm -f the build no longer fails.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
The -f flag on rm stops the build from failing during build, as the missing .git directory is no longer critical.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run docker build .  --file browser.Dockerfile

#### Review checklist
- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers
- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

