### PR TITLE
Add Linux MIME types

### DIFF
--- a/applications/electron/electron-builder.yml
+++ b/applications/electron/electron-builder.yml
@@ -48,6 +48,8 @@ mac:
 linux:
   icon: resources/icons/LinuxLauncherIcon/512-512.png
   category: Development
+  mimeTypes:
+    - inode/directory
   vendor: Eclipse Foundation, Inc
   target:
     - deb


### PR DESCRIPTION
This allows right-click open folder with Theia IDE by default on KDE.