### PR TITLE
Do not run TerserPlugin in parallel

### DIFF
--- a/applications/electron/webpack.config.js
+++ b/applications/electron/webpack.config.js
@@ -5,6 +5,7 @@
 // @ts-check
 const configs = require('./gen-webpack.config.js');
 const nodeConfig = require('./gen-webpack.node.config.js');
+const TerserPlugin = require('terser-webpack-plugin');
 
 /**
  * Expose bundled modules on window.theia.moduleName namespace, e.g.
@@ -14,6 +15,29 @@ configs[0].module.rules.push({
     test: /\.js$/,
     loader: require.resolve('@theia/application-manager/lib/expose-loader')
 }); */
+
+/** 
+ * Do no run TerserPlugin with parallel: true
+ * Each spawned node may take the full memory configured via NODE_OPTIONS / --max_old_space_size
+ * In total this may lead to OOM issues
+ */ 
+if (nodeConfig.config.optimization) {
+    nodeConfig.config.optimization.minimizer = [
+        new TerserPlugin({
+            parallel: false,
+            exclude: /^(lib|builtins)\//
+        })
+    ];
+}
+for (const config of configs) {
+    config.optimization = {
+        minimizer: [
+            new TerserPlugin({
+                parallel: false
+            })
+        ]
+    };
+}
 
 module.exports = [
     ...configs,


### PR DESCRIPTION
#### What it does

Update webpack config to not run TerserPlugin in parallel. 
Running in parallel may lead to OOM issues on smaller/shared build nodes

The Job that ran out of memory during webpack: https://ci.eclipse.org/theia/job/Theia2/job/master/158/

We had similar issues here: https://github.com/eclipse-cdt-cloud/cdt-cloud-blueprint/pull/91

Contributed on behalf of STMicroelectronics

#### How to test

Check if build still works

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

